### PR TITLE
Feature/add diagrams auto

### DIFF
--- a/.github/workflows/monthly_workflow.yaml
+++ b/.github/workflows/monthly_workflow.yaml
@@ -112,16 +112,22 @@ jobs:
   terraform_integration_tests:
     permissions:
       id-token: write
-      contents: write  # Necesario para commit-changes: 'push'
-      pull-requests: write  # Necesario si se quiere crear PRs en el futuro
+      contents: write # Required for commit-changes: push
+      pull-requests: write # Required if PRs need to be created in the future
 
     name: Integration-${{ matrix.config_files }}
     runs-on: ubuntu-latest
     if: always()
     needs: [load_scenarios, mock_plan_scenarios]
 
+    # Groups by individual test case to allow controlled parallelization
+    concurrency:
+      group: integration-${{ matrix.config_files }}-${{ github.run_id }}
+      cancel-in-progress: false
+
     strategy:
       fail-fast: false
+      max-parallel: 5 # Allows up to 5 different groups in parallel
       matrix: ${{fromJSON(needs.load_scenarios.outputs.matrix)}}
 
     environment:
@@ -198,12 +204,12 @@ jobs:
         id: get_resource_groups
         continue-on-error: true
         run: |
-          # Obtener IDs de Resource Groups del estado de Terraform
+          # Get Resource Group IDs from Terraform state
           RG_IDS=$(terraform -chdir=${GITHUB_WORKSPACE}/examples \
             show \
             -state=${{ env.STATE_FILE }} \
             -json | jq -r '.values.root_module.resources[]? | select(.type == "azurerm_resource_group") | .values.id' | tr '\n' ' ')
-          
+
           if [ -n "$RG_IDS" ]; then
             echo "RESOURCE_GROUP_IDS=$RG_IDS" >> $GITHUB_ENV
             echo "Found Resource Groups: $RG_IDS"
@@ -221,7 +227,7 @@ jobs:
           output-path: ${{ env.CURRENT_FOLDER }}/azure-infrastructure.drawio
           diagram-mode: all
           no-embed-data: true
-          commit-changes: 'push'
+          commit-changes: push
 
       - name: Terraform Destroy Plan
         id: tf_destroy_plan

--- a/.github/workflows/monthly_workflow.yaml
+++ b/.github/workflows/monthly_workflow.yaml
@@ -112,7 +112,8 @@ jobs:
   terraform_integration_tests:
     permissions:
       id-token: write
-      contents: read
+      contents: write  # Necesario para commit-changes: 'push'
+      pull-requests: write  # Necesario si se quiere crear PRs en el futuro
 
     name: Integration-${{ matrix.config_files }}
     runs-on: ubuntu-latest
@@ -192,6 +193,35 @@ jobs:
             apply \
             -state=${{ env.STATE_FILE }} \
             ${{ env.PLAN_FILE }}
+
+      - name: Get Resource Groups from Terraform State
+        id: get_resource_groups
+        continue-on-error: true
+        run: |
+          # Obtener IDs de Resource Groups del estado de Terraform
+          RG_IDS=$(terraform -chdir=${GITHUB_WORKSPACE}/examples \
+            show \
+            -state=${{ env.STATE_FILE }} \
+            -json | jq -r '.values.root_module.resources[]? | select(.type == "azurerm_resource_group") | .values.id' | tr '\n' ' ')
+          
+          if [ -n "$RG_IDS" ]; then
+            echo "RESOURCE_GROUP_IDS=$RG_IDS" >> $GITHUB_ENV
+            echo "Found Resource Groups: $RG_IDS"
+          else
+            echo "No Resource Groups found in Terraform state"
+            echo "RESOURCE_GROUP_IDS=" >> $GITHUB_ENV
+          fi
+
+      - name: Generate Azure Infrastructure Diagram
+        id: generate_diagram
+        continue-on-error: true
+        uses: rfernandezdo/inventariographdrawio@v2
+        with:
+          include-ids: ${{ env.RESOURCE_GROUP_IDS }}
+          output-path: ${{ env.CURRENT_FOLDER }}/azure-infrastructure.drawio
+          diagram-mode: all
+          no-embed-data: true
+          commit-changes: 'push'
 
       - name: Terraform Destroy Plan
         id: tf_destroy_plan


### PR DESCRIPTION
This pull request updates the `monthly_workflow.yaml` GitHub Actions workflow to improve integration test job management and add automated Azure infrastructure diagram generation. The main changes include enhanced permissions, parallelization controls, and new steps for extracting resource group IDs and generating diagrams from Terraform state.

**Workflow improvements:**

* Increased `contents` permission from `read` to `write` and added `pull-requests: write` to support future PR creation and allow committing generated files.
* Introduced `concurrency` and set `max-parallel: 5` in the `strategy` block to better control parallel execution of integration tests.

**Azure infrastructure diagram automation:**

* Added a step to extract Azure Resource Group IDs from the Terraform state using `jq` and store them in the environment for later use.
* Added a step to generate an Azure infrastructure diagram using the `inventariographdrawio` GitHub Action, outputting a `.drawio` file and committing it to the repository.

