### PR TITLE
Add PE custom_network_interface_name

### DIFF
--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -10,11 +10,12 @@ resource "azurecaf_name" "pep" {
 }
 
 resource "azurerm_private_endpoint" "pep" {
-  name                = azurecaf_name.pep.result
-  location            = local.location
-  resource_group_name = local.resource_group_name
-  subnet_id           = var.subnet_id
-  tags                = local.tags
+  name                          = azurecaf_name.pep.result
+  location                      = local.location
+  resource_group_name           = local.resource_group_name
+  subnet_id                     = var.subnet_id
+  custom_network_interface_name = try(var.custom_network_interface_name, null)
+  tags                          = local.tags
 
   private_service_connection {
     name                           = var.settings.private_service_connection.name

--- a/modules/networking/private_endpoint/private_endpoint.tf
+++ b/modules/networking/private_endpoint/private_endpoint.tf
@@ -14,7 +14,7 @@ resource "azurerm_private_endpoint" "pep" {
   location                      = local.location
   resource_group_name           = local.resource_group_name
   subnet_id                     = var.subnet_id
-  custom_network_interface_name = try(var.custom_network_interface_name, null)
+  custom_network_interface_name = try(var.settings.custom_network_interface_name, null)
   tags                          = local.tags
 
   private_service_connection {


### PR DESCRIPTION


## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This pull requests adds an option to specify a custom_network_interface_name on private endpoints.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
