### PR TITLE
Update setup-python action to version v6

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@trunk
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - name: Install dependencies


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow by updating the version of the `actions/setup-python` GitHub Action to ensure compatibility and reliability.

- Updated the `actions/setup-python` action from an invalid or placeholder version (`@trunk`) to the latest stable version (`@v6`) in the `.github/workflows/deploy-docs.yml` workflow file.