### PR TITLE
Managed Disk optimization

### DIFF
--- a/modules/compute/virtual_machine/vm_disk.tf
+++ b/modules/compute/virtual_machine/vm_disk.tf
@@ -27,7 +27,8 @@ resource "azurerm_managed_disk" "disk" {
   disk_encryption_set_id = can(each.value.disk_encryption_set_id) ? each.value.disk_encryption_set_id : can(each.value.disk_encryption_set_key) ? var.disk_encryption_sets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.disk_encryption_set_key].id : null
   lifecycle {
     ignore_changes = [
-      name, #for ASR disk restores
+      name,               #for ASR disk restores
+      storage_account_id, #for ASR disk restores
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adding two minor features for the managed disks. 

## Description

- Add max_shares as an optional property on the azurerm_managed_disk
- ignore the storage_account_id on azurerm_managed_disk to prevent recreation after an ASR restore

## Does this introduce a breaking change

- [ ] YES
- [x] NO
