### PR TITLE
fix: restore terraform/* in CAF Orchestrator agent

### DIFF
--- a/.github/agents/caf-orchestrator.agent.md
+++ b/.github/agents/caf-orchestrator.agent.md
@@ -9,14 +9,14 @@ tools:
   - terraform/*
   - todo
 agents:
-  - Module Builder
-  - Module Updater
-  - Migration Assistant
-  - Example Generator
-  - Compliance Validator
-  - Documentation Sync
-  - CI Workflow Manager
-  - Remote State Orchestrator
+  - Module Builder CAF
+  - Module Updater CAF
+  - Example Generator CAF
+  - Compliance Validator CAF
+  - Root Module Integration CAF
+  - Diagnostics Integration CAF
+  - Private Endpoint Integration CAF
+  - Schema Validator CAF
 model:
   - "GPT-5.3-Codex (copilot)"
   - "Claude Sonnet 4.6 (copilot)"


### PR DESCRIPTION
## Summary\n- restore  in \n- keep  tool normalized\n- update frontmatter  entries to valid CAF agent names in current catalog\n\n## Why\nThe orchestrator needs Terraform capabilities for end-to-end module flows and should reference valid agent identifiers.