### PR TITLE
Add PostgreSQL user

### DIFF
--- a/.github/workflows/standalone-dataplat.json
+++ b/.github/workflows/standalone-dataplat.json
@@ -55,7 +55,9 @@
     "postgresql_flexible_server/100-simple-postgresql-flexible",
     "postgresql_flexible_server/101-delegated-subnet-with-fw-rule",
     "postgresql_flexible_server/102-advanced-postgresql-flexible",
+    "postgresql_flexible_server/103-simple-postgresql-flexible-with-az-auth",
     "postgresql_flexible_server/104-private-endpoint",
+    "postgresql_flexible_server/105-postgresql-flexible-with-users",
     "powerbi_embedded/100-simple-powerbi",
     "purview/100-purview_account",
     "purview/101-purview_account_private_link"

--- a/examples/postgresql_flexible_server/105-postgresql-flexible-with-users/configuration.tfvars
+++ b/examples/postgresql_flexible_server/105-postgresql-flexible-with-users/configuration.tfvars
@@ -1,0 +1,106 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "uksouth"
+  }
+}
+
+resource_groups = {
+  postgresql_region1 = {
+    name   = "postgresql-region1"
+    region = "region1"
+  }
+  security_region1 = {
+    name = "security-region1"
+  }
+}
+
+# Managed Service Identity (MSI) used to demonstrate db_permissions
+managed_identities = {
+  app_msi = {
+    name               = "app-msi"
+    resource_group_key = "postgresql_region1"
+  }
+}
+
+postgresql_flexible_servers = {
+  primary_region1 = {
+    name       = "primary-region1"
+    region     = "region1"
+    version    = "14"
+    sku_name   = "GP_Standard_D2s_v3"
+    zone       = 1
+    storage_mb = 32768
+
+    resource_group = {
+      key = "postgresql_region1"
+    }
+
+    # Auto-generated administrator credentials stored in azure keyvault when not set (recommended).
+    # administrator_username = "pgadmin"
+    keyvault = {
+      key = "postgresql_region1"
+    }
+
+    postgresql_firewall_rules = {
+      allow-azure-internal = {
+        name             = "allow-azure-internal"
+        start_ip_address = "0.0.0.0"
+        end_ip_address   = "0.0.0.0"
+      }
+    }
+
+    postgresql_databases = {
+      appdb = {
+        name = "appdb"
+      }
+    }
+
+    # [Optional] Create local database users with passwords stored in Key Vault.
+    # This will create a user in the database with the given role.
+    # The password is auto-generated and stored in the Key Vault under the secret:
+    #   "<server_name>-<database>-<key>-password"
+    postgresql_users = {
+      app_reader = {
+        name     = "appreader"
+        role     = "pg_read_all_data"
+        database = "appdb"
+      }
+      app_writer = {
+        name     = "appwriter"
+        role     = "pg_write_all_data"
+        database = "appdb"
+      }
+    }
+
+    # [Optional] Grant database roles to Managed Identities or AAD groups.
+    # The MSI/group must first be created as a role in the database, then granted the specified db_roles.
+    # db_usernames are resolved from the remote managed identity name (or AAD group display_name).
+    db_permissions = {
+      app_msi_permissions = {
+        database = "appdb"
+        db_roles = ["pg_read_all_data", "pg_write_all_data"]
+        managed_identities = {
+          lz_key = "" # leave empty to use the current landing zone
+          keys   = ["app_msi"]
+        }
+      }
+    }
+
+  }
+}
+
+# Store administrator credentials into Key Vault.
+keyvaults = {
+  postgresql_region1 = {
+    name                = "akv"
+    resource_group_key  = "security_region1"
+    sku_name            = "standard"
+    soft_delete_enabled = true
+    creation_policies = {
+      logged_in_user = {
+        secret_permissions = ["Set", "Get", "List", "Delete", "Purge"]
+      }
+    }
+  }
+}

--- a/modules/databases/postgresql_flexible_server/db_permissions.tf
+++ b/modules/databases/postgresql_flexible_server/db_permissions.tf
@@ -5,9 +5,6 @@ resource "null_resource" "set_db_permissions" {
     db_usernames = join(",", each.value.db_usernames)
     db_roles     = join(",", each.value.db_roles)
     database     = each.value.database
-    server_fqdn  = local.server_fqdn
-    admin_user   = try(var.settings.administrator_username, "pgadmin")
-    admin_pwd    = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
   }
 
   provisioner "local-exec" {
@@ -15,15 +12,29 @@ resource "null_resource" "set_db_permissions" {
     interpreter = ["/bin/bash"]
     on_failure  = fail
     environment = {
-      PGHOST       = self.triggers.server_fqdn
+      PGHOST       = local.server_fqdn
       PGPORT       = "5432"
-      PGDATABASE   = self.triggers.database
-      DBADMINUSER  = self.triggers.admin_user
-      DBADMINPWD   = self.triggers.admin_pwd
-      DBUSERNAMES  = format("'%s'", self.triggers.db_usernames)
-      DBROLES      = format("'%s'", self.triggers.db_roles)
+      PGDATABASE   = each.value.database
+      DBADMINUSER  = try(var.settings.administrator_username, "pgadmin")
+      DBADMINPWD   = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
+      DBUSERNAMES  = format("'%s'", join(",", each.value.db_usernames))
+      DBROLES      = format("'%s'", join(",", each.value.db_roles))
       SQLFILEPATH  = format("%s/scripts/set_db_permissions.sql", path.module)
     }
+  }
+}
+
+# Separate null_resource for cleanup on destroy to avoid state/code mismatch
+resource "null_resource" "revoke_db_permissions" {
+  for_each = local.db_permissions
+
+  triggers = {
+    db_usernames = join(",", each.value.db_usernames)
+    db_roles     = join(",", each.value.db_roles)
+    database     = each.value.database
+    server_fqdn  = local.server_fqdn
+    admin_user   = try(var.settings.administrator_username, "pgadmin")
+    admin_pwd    = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
   }
 
   provisioner "local-exec" {
@@ -40,4 +51,6 @@ resource "null_resource" "set_db_permissions" {
       DBUSERNAMES = self.triggers.db_usernames
     }
   }
+
+  depends_on = [null_resource.set_db_permissions]
 }

--- a/modules/databases/postgresql_flexible_server/db_permissions.tf
+++ b/modules/databases/postgresql_flexible_server/db_permissions.tf
@@ -5,9 +5,6 @@ resource "null_resource" "set_db_permissions" {
     db_usernames = join(",", each.value.db_usernames)
     db_roles     = join(",", each.value.db_roles)
     database     = each.value.database
-    server_fqdn  = local.server_fqdn
-    admin_user   = try(var.settings.administrator_username, "pgadmin")
-    admin_pwd    = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
   }
 
   provisioner "local-exec" {
@@ -32,11 +29,11 @@ resource "null_resource" "set_db_permissions" {
     interpreter = ["/bin/bash"]
     on_failure  = continue
     environment = {
-      PGHOST      = self.triggers.server_fqdn
+      PGHOST      = azurerm_postgresql_flexible_server.postgresql.fqdn
       PGPORT      = "5432"
       PGDATABASE  = self.triggers.database
-      DBADMINUSER = self.triggers.admin_user
-      DBADMINPWD  = self.triggers.admin_pwd
+      DBADMINUSER = try(var.settings.administrator_username, "pgadmin")
+      DBADMINPWD  = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
       DBUSERNAMES = self.triggers.db_usernames
     }
   }

--- a/modules/databases/postgresql_flexible_server/db_permissions.tf
+++ b/modules/databases/postgresql_flexible_server/db_permissions.tf
@@ -1,0 +1,25 @@
+resource "null_resource" "set_db_permissions" {
+  for_each = local.db_permissions
+
+  triggers = {
+    db_usernames = join(",", each.value.db_usernames)
+    db_roles     = join(",", each.value.db_roles)
+    database     = each.value.database
+  }
+
+  provisioner "local-exec" {
+    command     = format("%s/scripts/set_db_permissions.sh", path.module)
+    interpreter = ["/bin/bash"]
+    on_failure  = fail
+    environment = {
+      PGHOST       = local.server_fqdn
+      PGPORT       = "5432"
+      PGDATABASE   = each.value.database
+      DBADMINUSER  = try(var.settings.administrator_username, "pgadmin")
+      DBADMINPWD   = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
+      DBUSERNAMES  = format("'%s'", join(",", each.value.db_usernames))
+      DBROLES      = format("'%s'", join(",", each.value.db_roles))
+      SQLFILEPATH  = format("%s/scripts/set_db_permissions.sql", path.module)
+    }
+  }
+}

--- a/modules/databases/postgresql_flexible_server/db_permissions.tf
+++ b/modules/databases/postgresql_flexible_server/db_permissions.tf
@@ -5,6 +5,9 @@ resource "null_resource" "set_db_permissions" {
     db_usernames = join(",", each.value.db_usernames)
     db_roles     = join(",", each.value.db_roles)
     database     = each.value.database
+    server_fqdn  = local.server_fqdn
+    admin_user   = try(var.settings.administrator_username, "pgadmin")
+    admin_pwd    = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
   }
 
   provisioner "local-exec" {
@@ -12,13 +15,13 @@ resource "null_resource" "set_db_permissions" {
     interpreter = ["/bin/bash"]
     on_failure  = fail
     environment = {
-      PGHOST       = local.server_fqdn
+      PGHOST       = self.triggers.server_fqdn
       PGPORT       = "5432"
-      PGDATABASE   = each.value.database
-      DBADMINUSER  = try(var.settings.administrator_username, "pgadmin")
-      DBADMINPWD   = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
-      DBUSERNAMES  = format("'%s'", join(",", each.value.db_usernames))
-      DBROLES      = format("'%s'", join(",", each.value.db_roles))
+      PGDATABASE   = self.triggers.database
+      DBADMINUSER  = self.triggers.admin_user
+      DBADMINPWD   = self.triggers.admin_pwd
+      DBUSERNAMES  = format("'%s'", self.triggers.db_usernames)
+      DBROLES      = format("'%s'", self.triggers.db_roles)
       SQLFILEPATH  = format("%s/scripts/set_db_permissions.sql", path.module)
     }
   }
@@ -29,11 +32,11 @@ resource "null_resource" "set_db_permissions" {
     interpreter = ["/bin/bash"]
     on_failure  = continue
     environment = {
-      PGHOST      = azurerm_postgresql_flexible_server.postgresql.fqdn
+      PGHOST      = self.triggers.server_fqdn
       PGPORT      = "5432"
       PGDATABASE  = self.triggers.database
-      DBADMINUSER = try(var.settings.administrator_username, "pgadmin")
-      DBADMINPWD  = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
+      DBADMINUSER = self.triggers.admin_user
+      DBADMINPWD  = self.triggers.admin_pwd
       DBUSERNAMES = self.triggers.db_usernames
     }
   }

--- a/modules/databases/postgresql_flexible_server/db_permissions.tf
+++ b/modules/databases/postgresql_flexible_server/db_permissions.tf
@@ -5,6 +5,9 @@ resource "null_resource" "set_db_permissions" {
     db_usernames = join(",", each.value.db_usernames)
     db_roles     = join(",", each.value.db_roles)
     database     = each.value.database
+    server_fqdn  = local.server_fqdn
+    admin_user   = try(var.settings.administrator_username, "pgadmin")
+    admin_pwd    = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
   }
 
   provisioner "local-exec" {
@@ -20,6 +23,21 @@ resource "null_resource" "set_db_permissions" {
       DBUSERNAMES  = format("'%s'", join(",", each.value.db_usernames))
       DBROLES      = format("'%s'", join(",", each.value.db_roles))
       SQLFILEPATH  = format("%s/scripts/set_db_permissions.sql", path.module)
+    }
+  }
+
+  provisioner "local-exec" {
+    when        = destroy
+    command     = format("%s/scripts/revoke_db_permissions.sh", path.module)
+    interpreter = ["/bin/bash"]
+    on_failure  = continue
+    environment = {
+      PGHOST      = self.triggers.server_fqdn
+      PGPORT      = "5432"
+      PGDATABASE  = self.triggers.database
+      DBADMINUSER = self.triggers.admin_user
+      DBADMINPWD  = self.triggers.admin_pwd
+      DBUSERNAMES = self.triggers.db_usernames
     }
   }
 }

--- a/modules/databases/postgresql_flexible_server/db_users.tf
+++ b/modules/databases/postgresql_flexible_server/db_users.tf
@@ -1,0 +1,77 @@
+data "azurerm_key_vault_secret" "postgresql_admin_password" {
+  count        = try(var.settings.postgresql_users, null) == null ? 0 : 1
+  name         = format("%s-password", azurecaf_name.postgresql_flexible_server.result)
+  key_vault_id = try(var.remote_objects.keyvault_id, null)
+}
+
+resource "random_password" "pg_user" {
+  for_each         = try(var.settings.postgresql_users, {})
+  length           = 128
+  special          = true
+  upper            = true
+  numeric          = true
+  override_special = "$#%"
+}
+
+resource "azurerm_key_vault_secret" "pg_user_password" {
+  for_each     = try(var.settings.postgresql_users, {})
+  name         = format("%s-%s-%s-password", azurecaf_name.postgresql_flexible_server.result, each.value.database, each.key)
+  value        = random_password.pg_user[each.key].result
+  key_vault_id = try(var.remote_objects.keyvault_id, null)
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "null_resource" "create_pg_user" {
+  depends_on = [azurerm_postgresql_flexible_server.postgresql]
+  for_each   = try(var.settings.postgresql_users, {})
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash"]
+    on_failure  = fail
+    command     = format("%s/scripts/create_pg_user.sh", path.module)
+    environment = {
+      PGHOST           = local.server_fqdn
+      PGPORT           = "5432"
+      PGDATABASE       = each.value.database
+      DBADMINUSER      = try(var.settings.administrator_username, "pgadmin")
+      DBADMINPWD       = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
+      DBUSERNAMES      = each.value.name
+      DBROLES          = each.value.role
+      DBUSERPASSWORDS  = azurerm_key_vault_secret.pg_user_password[each.key].value
+      SQLLOGINFILEPATH = format("%s/scripts/create_pg_login.sql", path.module)
+      SQLUSERFILEPATH  = format("%s/scripts/create_pg_user.sql", path.module)
+    }
+  }
+}
+
+resource "null_resource" "delete_pg_user" {
+  depends_on = [azurerm_postgresql_flexible_server.postgresql]
+  for_each   = try(var.settings.postgresql_users, {})
+  triggers = {
+    pg_server_fqdn     = local.server_fqdn
+    pg_server_db_name  = each.value.database
+    db_admin_user      = try(var.settings.administrator_username, "pgadmin")
+    db_admin_password  = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
+    db_user_name       = each.value.name
+    pg_login_filepath  = format("%s/scripts/delete_pg_login.sql", path.module)
+    pg_user_filepath   = format("%s/scripts/delete_pg_user.sql", path.module)
+  }
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash"]
+    when        = destroy
+    command     = format("%s/scripts/delete_pg_user.sh", path.module)
+    on_failure  = fail
+    environment = {
+      PGHOST           = self.triggers.pg_server_fqdn
+      PGPORT           = "5432"
+      PGDATABASE       = self.triggers.pg_server_db_name
+      DBADMINUSER      = self.triggers.db_admin_user
+      DBADMINPWD       = self.triggers.db_admin_password
+      DBUSERNAMES      = self.triggers.db_user_name
+      SQLLOGINFILEPATH = self.triggers.pg_login_filepath
+      SQLUSERFILEPATH  = self.triggers.pg_user_filepath
+    }
+  }
+}

--- a/modules/databases/postgresql_flexible_server/db_users.tf
+++ b/modules/databases/postgresql_flexible_server/db_users.tf
@@ -15,7 +15,7 @@ resource "random_password" "pg_user" {
 
 resource "azurerm_key_vault_secret" "pg_user_password" {
   for_each     = try(var.settings.postgresql_users, {})
-  name         = format("%s-%s-%s-password", azurecaf_name.postgresql_flexible_server.result, each.value.database, each.key)
+  name         = replace(format("%s-%s-%s-password", azurecaf_name.postgresql_flexible_server.result, each.value.database, each.key), "_", "-")
   value        = random_password.pg_user[each.key].result
   key_vault_id = try(var.remote_objects.keyvault_id, null)
   lifecycle {

--- a/modules/databases/postgresql_flexible_server/db_users.tf
+++ b/modules/databases/postgresql_flexible_server/db_users.tf
@@ -46,32 +46,32 @@ resource "null_resource" "create_pg_user" {
   }
 }
 
-resource "null_resource" "delete_pg_user" {
-  depends_on = [azurerm_postgresql_flexible_server.postgresql]
-  for_each   = try(var.settings.postgresql_users, {})
-  triggers = {
-    pg_server_fqdn     = local.server_fqdn
-    pg_server_db_name  = each.value.database
-    db_admin_user      = try(var.settings.administrator_username, "pgadmin")
-    db_admin_password  = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
-    db_user_name       = each.value.name
-    pg_login_filepath  = format("%s/scripts/delete_pg_login.sql", path.module)
-    pg_user_filepath   = format("%s/scripts/delete_pg_user.sql", path.module)
-  }
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash"]
-    when        = destroy
-    command     = format("%s/scripts/delete_pg_user.sh", path.module)
-    on_failure  = fail
-    environment = {
-      PGHOST           = self.triggers.pg_server_fqdn
-      PGPORT           = "5432"
-      PGDATABASE       = self.triggers.pg_server_db_name
-      DBADMINUSER      = self.triggers.db_admin_user
-      DBADMINPWD       = self.triggers.db_admin_password
-      DBUSERNAMES      = self.triggers.db_user_name
-      SQLLOGINFILEPATH = self.triggers.pg_login_filepath
-      SQLUSERFILEPATH  = self.triggers.pg_user_filepath
-    }
-  }
-}
+# resource "null_resource" "delete_pg_user" {
+#   depends_on = [azurerm_postgresql_flexible_server.postgresql]
+#   for_each   = try(var.settings.postgresql_users, {})
+#   triggers = {
+#     pg_server_fqdn     = local.server_fqdn
+#     pg_server_db_name  = each.value.database
+#     db_admin_user      = try(var.settings.administrator_username, "pgadmin")
+#     db_admin_password  = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
+#     db_user_name       = each.value.name
+#     pg_login_filepath  = format("%s/scripts/delete_pg_login.sql", path.module)
+#     pg_user_filepath   = format("%s/scripts/delete_pg_user.sql", path.module)
+#   }
+#   provisioner "local-exec" {
+#     interpreter = ["/bin/bash"]
+#     when        = destroy
+#     command     = format("%s/scripts/delete_pg_user.sh", path.module)
+#     on_failure  = fail
+#     environment = {
+#       PGHOST           = self.triggers.pg_server_fqdn
+#       PGPORT           = "5432"
+#       PGDATABASE       = self.triggers.pg_server_db_name
+#       DBADMINUSER      = self.triggers.db_admin_user
+#       DBADMINPWD       = self.triggers.db_admin_password
+#       DBUSERNAMES      = self.triggers.db_user_name
+#       SQLLOGINFILEPATH = self.triggers.pg_login_filepath
+#       SQLUSERFILEPATH  = self.triggers.pg_user_filepath
+#     }
+#   }
+# }

--- a/modules/databases/postgresql_flexible_server/db_users.tf
+++ b/modules/databases/postgresql_flexible_server/db_users.tf
@@ -46,32 +46,32 @@ resource "null_resource" "create_pg_user" {
   }
 }
 
-# resource "null_resource" "delete_pg_user" {
-#   depends_on = [azurerm_postgresql_flexible_server.postgresql]
-#   for_each   = try(var.settings.postgresql_users, {})
-#   triggers = {
-#     pg_server_fqdn     = local.server_fqdn
-#     pg_server_db_name  = each.value.database
-#     db_admin_user      = try(var.settings.administrator_username, "pgadmin")
-#     db_admin_password  = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
-#     db_user_name       = each.value.name
-#     pg_login_filepath  = format("%s/scripts/delete_pg_login.sql", path.module)
-#     pg_user_filepath   = format("%s/scripts/delete_pg_user.sql", path.module)
-#   }
-#   provisioner "local-exec" {
-#     interpreter = ["/bin/bash"]
-#     when        = destroy
-#     command     = format("%s/scripts/delete_pg_user.sh", path.module)
-#     on_failure  = fail
-#     environment = {
-#       PGHOST           = self.triggers.pg_server_fqdn
-#       PGPORT           = "5432"
-#       PGDATABASE       = self.triggers.pg_server_db_name
-#       DBADMINUSER      = self.triggers.db_admin_user
-#       DBADMINPWD       = self.triggers.db_admin_password
-#       DBUSERNAMES      = self.triggers.db_user_name
-#       SQLLOGINFILEPATH = self.triggers.pg_login_filepath
-#       SQLUSERFILEPATH  = self.triggers.pg_user_filepath
-#     }
-#   }
-# }
+resource "null_resource" "delete_pg_user" {
+  depends_on = [azurerm_postgresql_flexible_server.postgresql]
+  for_each   = try(var.settings.postgresql_users, {})
+  triggers = {
+    pg_server_fqdn     = local.server_fqdn
+    pg_server_db_name  = each.value.database
+    db_admin_user      = try(var.settings.administrator_username, "pgadmin")
+    db_admin_password  = try(azurerm_postgresql_flexible_server.postgresql.administrator_password, data.azurerm_key_vault_secret.postgresql_admin_password[0].value)
+    db_user_name       = each.value.name
+    pg_login_filepath  = format("%s/scripts/delete_pg_login.sql", path.module)
+    pg_user_filepath   = format("%s/scripts/delete_pg_user.sql", path.module)
+  }
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash"]
+    when        = destroy
+    command     = format("%s/scripts/delete_pg_user.sh", path.module)
+    on_failure  = fail
+    environment = {
+      PGHOST           = self.triggers.pg_server_fqdn
+      PGPORT           = "5432"
+      PGDATABASE       = self.triggers.pg_server_db_name
+      DBADMINUSER      = self.triggers.db_admin_user
+      DBADMINPWD       = self.triggers.db_admin_password
+      DBUSERNAMES      = self.triggers.db_user_name
+      SQLLOGINFILEPATH = self.triggers.pg_login_filepath
+      SQLUSERFILEPATH  = self.triggers.pg_user_filepath
+    }
+  }
+}

--- a/modules/databases/postgresql_flexible_server/locals_postgresql_users.tf
+++ b/modules/databases/postgresql_flexible_server/locals_postgresql_users.tf
@@ -1,0 +1,31 @@
+locals {
+  server_fqdn = azurerm_postgresql_flexible_server.postgresql.fqdn
+
+  db_permissions = {
+    for group_key, group in try(var.settings.db_permissions, {}) : group_key => {
+      database   = group.database
+      db_roles   = group.db_roles
+
+      db_usernames = distinct(compact(flatten(concat(
+        [
+          for mi_key, mi_value in try(group, {}) : [
+            for k in try(mi_value.keys, mi_value.managed_identity_keys, []) :
+            try(
+              var.remote_objects.managed_identities[try(mi_value.lz_key, var.client_config.landingzone_key)][k].name,
+              null
+            )
+          ] if mi_key == "managed_identities"
+        ],
+        [
+          for aad_key, aad_value in try(group, {}) : [
+            for k in try(aad_value.keys, []) :
+            try(
+              var.remote_objects.azuread_groups[try(aad_value.lz_key, var.client_config.landingzone_key)][k].display_name,
+              null
+            )
+          ] if aad_key == "azuread_groups"
+        ]
+      ))))
+    }
+  }
+}

--- a/modules/databases/postgresql_flexible_server/main.tf
+++ b/modules/databases/postgresql_flexible_server/main.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.1"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.1"
+    }
   }
 }

--- a/modules/databases/postgresql_flexible_server/outputs.tf
+++ b/modules/databases/postgresql_flexible_server/outputs.tf
@@ -61,6 +61,20 @@ output "postgresql_flexible_server_firewall_rule_id" {
   }
 }
 
+output "postgresql_flexible_server_users" {
+  description = "IDs of the PostgreSQL flexible server users"
+  value = {
+    for k, v in try(null_resource.create_pg_user, {}) : k => v.id
+  }
+}
+
+output "postgresql_flexible_server_user_secret_ids" {
+  description = "IDs of the PostgreSQL user password secrets in Key Vault"
+  value = {
+    for k, v in azurerm_key_vault_secret.pg_user_password : k => v.id
+  }
+}
+
 output "resource_group_name" {
   description = "Name of the Resource Group where the resource exists."
   value       = local.resource_group_name

--- a/modules/databases/postgresql_flexible_server/scripts/create_pg_login.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/create_pg_login.sql
@@ -1,43 +1,14 @@
 -- Create PostgreSQL login (server-level role)
--- Split comma-separated usernames and passwords
+-- Single user per call from Terraform
 
 DO $$
-DECLARE
-    v_dbusernames VARCHAR(1000) := :'DBUSERNAMES';
-    v_dbuserpasswords VARCHAR(2000) := :'DBUSERPASSWORDS';
-    v_username VARCHAR(100);
-    v_userpwd VARCHAR(500);
-    v_sql VARCHAR(500);
 BEGIN
-    WHILE LENGTH(v_dbusernames) > 0 LOOP
-        -- Extract first username
-        IF POSITION(',' IN v_dbusernames) > 0 THEN
-            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
-            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
-        ELSE
-            v_username := v_dbusernames;
-            v_dbusernames := '';
-        END IF;
-
-        -- Extract first password
-        IF POSITION(',' IN v_dbuserpasswords) > 0 THEN
-            v_userpwd := SUBSTRING(v_dbuserpasswords FROM 1 FOR POSITION(',' IN v_dbuserpasswords) - 1);
-            v_dbuserpasswords := SUBSTRING(v_dbuserpasswords FROM POSITION(',' IN v_dbuserpasswords) + 1);
-        ELSE
-            v_userpwd := v_dbuserpasswords;
-            v_dbuserpasswords := '';
-        END IF;
-
-        v_username := TRIM(v_username);
-
-        -- Check if login already exists
-        IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_user WHERE usename = v_username) THEN
-            v_sql := 'CREATE ROLE "' || v_username || '" WITH LOGIN PASSWORD ' || quote_literal(v_userpwd);
-            EXECUTE v_sql;
-            RAISE NOTICE 'Login created: %', v_username;
-        ELSE
-            RAISE NOTICE 'Login already exists: %', v_username;
-        END IF;
-    END LOOP;
+    -- Check if login already exists
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'DBUSERNAMES') THEN
+        EXECUTE 'CREATE USER "' || :'DBUSERNAMES' || '" WITH LOGIN PASSWORD ' || quote_literal(:'DBUSERPASSWORDS');
+        RAISE NOTICE 'Login created: %', :'DBUSERNAMES';
+    ELSE
+        RAISE NOTICE 'Login already exists: %', :'DBUSERNAMES';
+    END IF;
 END
 $$;

--- a/modules/databases/postgresql_flexible_server/scripts/create_pg_login.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/create_pg_login.sql
@@ -1,14 +1,4 @@
 -- Create PostgreSQL login (server-level role)
 -- Single user per call from Terraform
 
-DO $$
-BEGIN
-    -- Check if login already exists
-    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'DBUSERNAMES') THEN
-        EXECUTE 'CREATE USER "' || :'DBUSERNAMES' || '" WITH LOGIN PASSWORD ' || quote_literal(:'DBUSERPASSWORDS');
-        RAISE NOTICE 'Login created: %', :'DBUSERNAMES';
-    ELSE
-        RAISE NOTICE 'Login already exists: %', :'DBUSERNAMES';
-    END IF;
-END
-$$;
+CREATE USER :'DBUSERNAMES' WITH LOGIN PASSWORD :'DBUSERPASSWORDS';

--- a/modules/databases/postgresql_flexible_server/scripts/create_pg_login.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/create_pg_login.sql
@@ -1,0 +1,43 @@
+-- Create PostgreSQL login (server-level role)
+-- Split comma-separated usernames and passwords
+
+DO $$
+DECLARE
+    v_dbusernames VARCHAR(1000) := :'DBUSERNAMES';
+    v_dbuserpasswords VARCHAR(2000) := :'DBUSERPASSWORDS';
+    v_username VARCHAR(100);
+    v_userpwd VARCHAR(500);
+    v_sql VARCHAR(500);
+BEGIN
+    WHILE LENGTH(v_dbusernames) > 0 LOOP
+        -- Extract first username
+        IF POSITION(',' IN v_dbusernames) > 0 THEN
+            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
+            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
+        ELSE
+            v_username := v_dbusernames;
+            v_dbusernames := '';
+        END IF;
+
+        -- Extract first password
+        IF POSITION(',' IN v_dbuserpasswords) > 0 THEN
+            v_userpwd := SUBSTRING(v_dbuserpasswords FROM 1 FOR POSITION(',' IN v_dbuserpasswords) - 1);
+            v_dbuserpasswords := SUBSTRING(v_dbuserpasswords FROM POSITION(',' IN v_dbuserpasswords) + 1);
+        ELSE
+            v_userpwd := v_dbuserpasswords;
+            v_dbuserpasswords := '';
+        END IF;
+
+        v_username := TRIM(v_username);
+
+        -- Check if login already exists
+        IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_user WHERE usename = v_username) THEN
+            v_sql := 'CREATE ROLE "' || v_username || '" WITH LOGIN PASSWORD ' || quote_literal(v_userpwd);
+            EXECUTE v_sql;
+            RAISE NOTICE 'Login created: %', v_username;
+        ELSE
+            RAISE NOTICE 'Login already exists: %', v_username;
+        END IF;
+    END LOOP;
+END
+$$;

--- a/modules/databases/postgresql_flexible_server/scripts/create_pg_login.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/create_pg_login.sql
@@ -1,4 +1,8 @@
 -- Create PostgreSQL login (server-level role)
 -- Single user per call from Terraform
 
-CREATE USER :'DBUSERNAMES' WITH LOGIN PASSWORD :'DBUSERPASSWORDS';
+\echo 'Creating user:' :DBUSERNAMES
+
+CREATE ROLE :DBUSERNAMES WITH LOGIN PASSWORD :'DBUSERPASSWORDS';
+
+\echo 'User created successfully'

--- a/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sh
+++ b/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sh
@@ -4,10 +4,15 @@ set -e
 export PGPASSWORD="${DBADMINPWD}"
 export PGSSLMODE="require"
 
+echo "Creating PostgreSQL user: ${DBUSERNAMES}"
+
 # Create login on postgres database (server level)
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" -v DBUSERNAMES="${DBUSERNAMES}" -v DBUSERPASSWORDS="${DBUSERPASSWORDS}" -f "${SQLLOGINFILEPATH}"
+# Use -c to execute commands directly with proper escaping
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" \
+  -c "CREATE ROLE \"${DBUSERNAMES}\" WITH LOGIN PASSWORD '$( echo "${DBUSERPASSWORDS}" | sed "s/'/''/g" )'"
 
 # Create user and assign role on target database
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" -v DBUSERNAMES="${DBUSERNAMES}" -v DBROLES="${DBROLES}" -f "${SQLUSERFILEPATH}"
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" \
+  -c "GRANT \"${DBROLES}\" TO \"${DBUSERNAMES}\""
 
-echo "PostgreSQL user(s) created successfully"
+echo "PostgreSQL user created successfully"

--- a/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sh
+++ b/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+export PGPASSWORD="${DBADMINPWD}"
+export PGSSLMODE="require"
+
+# Create login on postgres database (server level)
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" -v DBUSERNAMES="${DBUSERNAMES}" -v DBUSERPASSWORDS="${DBUSERPASSWORDS}" -f "${SQLLOGINFILEPATH}"
+
+# Create user and assign role on target database
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" -v DBUSERNAMES="${DBUSERNAMES}" -v DBROLES="${DBROLES}" -f "${SQLUSERFILEPATH}"
+
+echo "PostgreSQL user(s) created successfully"

--- a/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sql
@@ -1,30 +1,12 @@
--- Create database user and assign role
--- Assumes login (server-level role) already exists from create_pg_login.sql
+-- Grant database role to user
+-- Assigns predefined PostgreSQL role to user account
 
 DO $$
-DECLARE
-    v_dbusernames VARCHAR(1000) := :'DBUSERNAMES';
-    v_dbroles VARCHAR(1000) := :'DBROLES';
-    v_username VARCHAR(100);
-    v_dbrole VARCHAR(100);
-    v_sql VARCHAR(500);
 BEGIN
-    WHILE LENGTH(v_dbusernames) > 0 LOOP
-        -- Extract first username
-        IF POSITION(',' IN v_dbusernames) > 0 THEN
-            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
-            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
-        ELSE
-            v_username := v_dbusernames;
-            v_dbusernames := '';
-        END IF;
-
-        v_username := TRIM(v_username);
-
-        -- Assign role from the login
-        v_sql := 'GRANT "' || :'DBROLES' || '" TO "' || v_username || '"';
-        EXECUTE v_sql;
-        RAISE NOTICE 'User % assigned to role %', v_username, :'DBROLES';
-    END LOOP;
+    -- Grant the specified role to the user
+    EXECUTE 'GRANT "' || :'DBROLES' || '" TO "' || :'DBUSERNAMES' || '"';
+    RAISE NOTICE 'User % assigned to role %', :'DBUSERNAMES', :'DBROLES';
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'Error assigning role: %', SQLERRM;
 END
 $$;

--- a/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sql
@@ -1,12 +1,4 @@
 -- Grant database role to user
 -- Assigns predefined PostgreSQL role to user account
 
-DO $$
-BEGIN
-    -- Grant the specified role to the user
-    EXECUTE 'GRANT "' || :'DBROLES' || '" TO "' || :'DBUSERNAMES' || '"';
-    RAISE NOTICE 'User % assigned to role %', :'DBUSERNAMES', :'DBROLES';
-EXCEPTION WHEN OTHERS THEN
-    RAISE NOTICE 'Error assigning role: %', SQLERRM;
-END
-$$;
+GRANT :'DBROLES' TO :'DBUSERNAMES';

--- a/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/create_pg_user.sql
@@ -1,0 +1,30 @@
+-- Create database user and assign role
+-- Assumes login (server-level role) already exists from create_pg_login.sql
+
+DO $$
+DECLARE
+    v_dbusernames VARCHAR(1000) := :'DBUSERNAMES';
+    v_dbroles VARCHAR(1000) := :'DBROLES';
+    v_username VARCHAR(100);
+    v_dbrole VARCHAR(100);
+    v_sql VARCHAR(500);
+BEGIN
+    WHILE LENGTH(v_dbusernames) > 0 LOOP
+        -- Extract first username
+        IF POSITION(',' IN v_dbusernames) > 0 THEN
+            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
+            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
+        ELSE
+            v_username := v_dbusernames;
+            v_dbusernames := '';
+        END IF;
+
+        v_username := TRIM(v_username);
+
+        -- Assign role from the login
+        v_sql := 'GRANT "' || :'DBROLES' || '" TO "' || v_username || '"';
+        EXECUTE v_sql;
+        RAISE NOTICE 'User % assigned to role %', v_username, :'DBROLES';
+    END LOOP;
+END
+$$;

--- a/modules/databases/postgresql_flexible_server/scripts/delete_pg_login.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/delete_pg_login.sql
@@ -1,23 +1,6 @@
 -- Delete PostgreSQL login (server-level role)
 -- Cleanup procedure on destroy
 
-DO $$
-BEGIN
-    -- Check if login exists
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'DBUSERNAMES') THEN
-        -- Reassign owned objects to current admin
-        EXECUTE 'REASSIGN OWNED BY "' || :'DBUSERNAMES' || '" TO current_user';
-        
-        -- Drop owned objects
-        EXECUTE 'DROP OWNED BY "' || :'DBUSERNAMES' || '"';
-        
-        -- Drop the role/login
-        EXECUTE 'DROP ROLE IF EXISTS "' || :'DBUSERNAMES' || '"';
-        RAISE NOTICE 'Login deleted: %', :'DBUSERNAMES';
-    ELSE
-        RAISE NOTICE 'Login does not exist: %', :'DBUSERNAMES';
-    END IF;
-EXCEPTION WHEN OTHERS THEN
-    RAISE NOTICE 'Error deleting login: %', SQLERRM;
-END
-$$;
+REASSIGN OWNED BY :'DBUSERNAMES' TO current_user;
+DROP OWNED BY :'DBUSERNAMES';
+DROP ROLE IF EXISTS :'DBUSERNAMES';

--- a/modules/databases/postgresql_flexible_server/scripts/delete_pg_login.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/delete_pg_login.sql
@@ -1,40 +1,23 @@
 -- Delete PostgreSQL login (server-level role)
+-- Cleanup procedure on destroy
 
 DO $$
-DECLARE
-    v_dbusernames VARCHAR(1000) := :'DBUSERNAMES';
-    v_username VARCHAR(100);
-    v_sql VARCHAR(500);
 BEGIN
-    WHILE LENGTH(v_dbusernames) > 0 LOOP
-        -- Extract first username
-        IF POSITION(',' IN v_dbusernames) > 0 THEN
-            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
-            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
-        ELSE
-            v_username := v_dbusernames;
-            v_dbusernames := '';
-        END IF;
-
-        v_username := TRIM(v_username);
-
-        -- Check if login exists and delete it
-        IF EXISTS (SELECT 1 FROM pg_catalog.pg_user WHERE usename = v_username) THEN
-            -- Reassign owned objects if needed
-            v_sql := 'REASSIGN OWNED BY "' || v_username || '" TO current_user';
-            EXECUTE v_sql;
-            
-            -- Drop owned objects
-            v_sql := 'DROP OWNED BY "' || v_username || '"';
-            EXECUTE v_sql;
-            
-            -- Drop the login
-            v_sql := 'DROP ROLE IF EXISTS "' || v_username || '"';
-            EXECUTE v_sql;
-            RAISE NOTICE 'Login deleted: %', v_username;
-        ELSE
-            RAISE NOTICE 'Login does not exist: %', v_username;
-        END IF;
-    END LOOP;
+    -- Check if login exists
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'DBUSERNAMES') THEN
+        -- Reassign owned objects to current admin
+        EXECUTE 'REASSIGN OWNED BY "' || :'DBUSERNAMES' || '" TO current_user';
+        
+        -- Drop owned objects
+        EXECUTE 'DROP OWNED BY "' || :'DBUSERNAMES' || '"';
+        
+        -- Drop the role/login
+        EXECUTE 'DROP ROLE IF EXISTS "' || :'DBUSERNAMES' || '"';
+        RAISE NOTICE 'Login deleted: %', :'DBUSERNAMES';
+    ELSE
+        RAISE NOTICE 'Login does not exist: %', :'DBUSERNAMES';
+    END IF;
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'Error deleting login: %', SQLERRM;
 END
 $$;

--- a/modules/databases/postgresql_flexible_server/scripts/delete_pg_login.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/delete_pg_login.sql
@@ -1,0 +1,40 @@
+-- Delete PostgreSQL login (server-level role)
+
+DO $$
+DECLARE
+    v_dbusernames VARCHAR(1000) := :'DBUSERNAMES';
+    v_username VARCHAR(100);
+    v_sql VARCHAR(500);
+BEGIN
+    WHILE LENGTH(v_dbusernames) > 0 LOOP
+        -- Extract first username
+        IF POSITION(',' IN v_dbusernames) > 0 THEN
+            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
+            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
+        ELSE
+            v_username := v_dbusernames;
+            v_dbusernames := '';
+        END IF;
+
+        v_username := TRIM(v_username);
+
+        -- Check if login exists and delete it
+        IF EXISTS (SELECT 1 FROM pg_catalog.pg_user WHERE usename = v_username) THEN
+            -- Reassign owned objects if needed
+            v_sql := 'REASSIGN OWNED BY "' || v_username || '" TO current_user';
+            EXECUTE v_sql;
+            
+            -- Drop owned objects
+            v_sql := 'DROP OWNED BY "' || v_username || '"';
+            EXECUTE v_sql;
+            
+            -- Drop the login
+            v_sql := 'DROP ROLE IF EXISTS "' || v_username || '"';
+            EXECUTE v_sql;
+            RAISE NOTICE 'Login deleted: %', v_username;
+        ELSE
+            RAISE NOTICE 'Login does not exist: %', v_username;
+        END IF;
+    END LOOP;
+END
+$$;

--- a/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sh
+++ b/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sh
@@ -4,10 +4,25 @@ set -e
 export PGPASSWORD="${DBADMINPWD}"
 export PGSSLMODE="require"
 
-# Delete user from target database
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" -v DBUSERNAMES="${DBUSERNAMES}" -f "${SQLUSERFILEPATH}"
+echo "Deleting PostgreSQL user: ${DBUSERNAMES}"
 
-# Delete login from postgres database (server level)
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" -v DBUSERNAMES="${DBUSERNAMES}" -f "${SQLLOGINFILEPATH}"
+# Revoke privileges on target database
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" \
+  -c "REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM \"${DBUSERNAMES}\""
 
-echo "PostgreSQL user(s) deleted successfully"
+# Revoke default privileges on target database
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" \
+  -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM \"${DBUSERNAMES}\""
+
+# Reassign and drop owned objects on postgres database (server level)
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" \
+  -c "REASSIGN OWNED BY \"${DBUSERNAMES}\" TO current_user"
+
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" \
+  -c "DROP OWNED BY \"${DBUSERNAMES}\""
+
+# Drop the login/role
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" \
+  -c "DROP ROLE IF EXISTS \"${DBUSERNAMES}\""
+
+echo "PostgreSQL user deleted successfully"

--- a/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sh
+++ b/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+export PGPASSWORD="${DBADMINPWD}"
+export PGSSLMODE="require"
+
+# Delete user from target database
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" -v DBUSERNAMES="${DBUSERNAMES}" -f "${SQLUSERFILEPATH}"
+
+# Delete login from postgres database (server level)
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" -v DBUSERNAMES="${DBUSERNAMES}" -f "${SQLLOGINFILEPATH}"
+
+echo "PostgreSQL user(s) deleted successfully"

--- a/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sh
+++ b/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sh
@@ -6,23 +6,16 @@ export PGSSLMODE="require"
 
 echo "Deleting PostgreSQL user: ${DBUSERNAMES}"
 
-# Revoke privileges on target database
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" \
-  -c "REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM \"${DBUSERNAMES}\""
+PSQL_POSTGRES="psql -h ${PGHOST} -p ${PGPORT} -U ${DBADMINUSER} -d postgres"
+PSQL_DBNAME="psql -h ${PGHOST} -p ${PGPORT} -U ${DBADMINUSER} -d ${PGDATABASE}"
 
-# Revoke default privileges on target database
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" \
-  -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM \"${DBUSERNAMES}\""
+# Drop owned objects in the target database (handles grants, default privileges, etc.)
+${PSQL_DBNAME} -c "DROP OWNED BY \"${DBUSERNAMES}\";" || true
 
-# Reassign and drop owned objects on postgres database (server level)
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" \
-  -c "REASSIGN OWNED BY \"${DBUSERNAMES}\" TO current_user"
+# Drop owned objects in postgres database (server-level)
+${PSQL_POSTGRES} -c "DROP OWNED BY \"${DBUSERNAMES}\";" || true
 
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" \
-  -c "DROP OWNED BY \"${DBUSERNAMES}\""
-
-# Drop the login/role
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "postgres" \
-  -c "DROP ROLE IF EXISTS \"${DBUSERNAMES}\""
+# Drop the role
+${PSQL_POSTGRES} -c "DROP ROLE IF EXISTS \"${DBUSERNAMES}\";"
 
 echo "PostgreSQL user deleted successfully"

--- a/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sql
@@ -1,19 +1,6 @@
 -- Revoke database roles and privileges
 -- Cleanup before login deletion
 
-DO $$
-BEGIN
-    -- Revoke all privileges on all tables in public schema
-    EXECUTE 'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM "' || :'DBUSERNAMES' || '"';
-    
-    -- Revoke default privileges
-    EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM "' || :'DBUSERNAMES' || '"';
-    
-    -- Revoke all database grants
-    EXECUTE 'REVOKE ALL PRIVILEGES ON DATABASE "' || current_database() || '" FROM "' || :'DBUSERNAMES' || '"';
-    
-    RAISE NOTICE 'Privileges revoked for user: %', :'DBUSERNAMES';
-EXCEPTION WHEN OTHERS THEN
-    RAISE NOTICE 'Error revoking privileges: %', SQLERRM;
-END
-$$;
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM :'DBUSERNAMES';
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM :'DBUSERNAMES';
+REVOKE ALL PRIVILEGES ON DATABASE :'CURRENT_DATABASE' FROM :'DBUSERNAMES';

--- a/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sql
@@ -1,0 +1,33 @@
+-- Delete database user role
+-- This removes the user from the database
+
+DO $$
+DECLARE
+    v_dbusernames VARCHAR(1000) := :'DBUSERNAMES';
+    v_username VARCHAR(100);
+    v_sql VARCHAR(500);
+BEGIN
+    WHILE LENGTH(v_dbusernames) > 0 LOOP
+        -- Extract first username
+        IF POSITION(',' IN v_dbusernames) > 0 THEN
+            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
+            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
+        ELSE
+            v_username := v_dbusernames;
+            v_dbusernames := '';
+        END IF;
+
+        v_username := TRIM(v_username);
+
+        -- Revoke all privileges on all tables in this database
+        v_sql := 'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM "' || v_username || '"';
+        EXECUTE v_sql;
+
+        -- Revoke default privileges
+        v_sql := 'ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM "' || v_username || '"';
+        EXECUTE v_sql;
+
+        RAISE NOTICE 'Privileges revoked for user: %', v_username;
+    END LOOP;
+END
+$$;

--- a/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/delete_pg_user.sql
@@ -1,33 +1,19 @@
--- Delete database user role
--- This removes the user from the database
+-- Revoke database roles and privileges
+-- Cleanup before login deletion
 
 DO $$
-DECLARE
-    v_dbusernames VARCHAR(1000) := :'DBUSERNAMES';
-    v_username VARCHAR(100);
-    v_sql VARCHAR(500);
 BEGIN
-    WHILE LENGTH(v_dbusernames) > 0 LOOP
-        -- Extract first username
-        IF POSITION(',' IN v_dbusernames) > 0 THEN
-            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
-            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
-        ELSE
-            v_username := v_dbusernames;
-            v_dbusernames := '';
-        END IF;
-
-        v_username := TRIM(v_username);
-
-        -- Revoke all privileges on all tables in this database
-        v_sql := 'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM "' || v_username || '"';
-        EXECUTE v_sql;
-
-        -- Revoke default privileges
-        v_sql := 'ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM "' || v_username || '"';
-        EXECUTE v_sql;
-
-        RAISE NOTICE 'Privileges revoked for user: %', v_username;
-    END LOOP;
+    -- Revoke all privileges on all tables in public schema
+    EXECUTE 'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM "' || :'DBUSERNAMES' || '"';
+    
+    -- Revoke default privileges
+    EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM "' || :'DBUSERNAMES' || '"';
+    
+    -- Revoke all database grants
+    EXECUTE 'REVOKE ALL PRIVILEGES ON DATABASE "' || current_database() || '" FROM "' || :'DBUSERNAMES' || '"';
+    
+    RAISE NOTICE 'Privileges revoked for user: %', :'DBUSERNAMES';
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'Error revoking privileges: %', SQLERRM;
 END
 $$;

--- a/modules/databases/postgresql_flexible_server/scripts/revoke_db_permissions.sh
+++ b/modules/databases/postgresql_flexible_server/scripts/revoke_db_permissions.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+export PGPASSWORD="${DBADMINPWD}"
+export PGSSLMODE="require"
+
+# Strip surrounding single quotes added by Terraform
+CLEANED_USERNAMES=$(echo "${DBUSERNAMES}" | sed "s/^'//;s/'$//")
+
+echo "Revoking database permissions for users: ${CLEANED_USERNAMES}"
+
+PSQL_DBNAME="psql -h ${PGHOST} -p ${PGPORT} -U ${DBADMINUSER} -d ${PGDATABASE}"
+
+# Split comma-separated usernames
+IFS=',' read -ra USERS <<< "${CLEANED_USERNAMES}"
+
+for USERNAME in "${USERS[@]}"; do
+  USERNAME=$(echo "${USERNAME}" | xargs)  # trim whitespace
+  echo "Revoking permissions for user: ${USERNAME}"
+
+  # Drop owned objects
+  ${PSQL_DBNAME} -c "DROP OWNED BY \"${USERNAME}\";" 2>/dev/null || true
+
+  # Drop the role if it exists
+  ${PSQL_DBNAME} -c "DROP ROLE IF EXISTS \"${USERNAME}\";" 2>/dev/null || true
+done
+
+echo "Database permissions revoked successfully"

--- a/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sh
+++ b/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sh
@@ -4,60 +4,43 @@ set -e
 export PGPASSWORD="${DBADMINPWD}"
 export PGSSLMODE="require"
 
-echo "Setting database permissions for users: ${DBUSERNAMES}"
+# Strip surrounding single quotes added by Terraform format("'%s'", ...)
+CLEANED_USERNAMES=$(echo "${DBUSERNAMES}" | sed "s/^'//;s/'$//")
+CLEANED_ROLES=$(echo "${DBROLES}" | sed "s/^'//;s/'$//")
 
-# Generate SQL dynamically with proper variable substitution
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" << EOSQL
-DO \\\$\\\$
-DECLARE
-    v_usernames TEXT := '$(echo "${DBUSERNAMES}" | sed "s/'/''/g")';
-    v_roles TEXT := '$(echo "${DBROLES}" | sed "s/'/''/g")';
-    v_username TEXT;
-    v_role TEXT;
-    v_user_array TEXT[];
-    v_role_array TEXT[];
-BEGIN
-    -- Remove surrounding quotes and split by comma
-    v_usernames := TRIM(BOTH '''' FROM v_usernames);
-    v_roles := TRIM(BOTH '''' FROM v_roles);
-    
-    v_user_array := STRING_TO_ARRAY(v_usernames, ',');
-    v_role_array := STRING_TO_ARRAY(v_roles, ',');
-    
-    RAISE NOTICE 'Processing users: %', v_usernames;
-    RAISE NOTICE 'Assigning roles: %', v_roles;
-    
-    -- Process each username
-    FOREACH v_username IN ARRAY v_user_array LOOP
-        v_username := TRIM(v_username);
-        
-        -- Create role from external provider (AAD/Managed Identity) if needed
-        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = v_username) THEN
-            BEGIN
-                EXECUTE 'CREATE ROLE ' || quote_identifier(v_username) || ' WITH LOGIN';
-                RAISE NOTICE 'Role created for: %', v_username;
-            EXCEPTION WHEN duplicate_object THEN
-                RAISE NOTICE 'Role already exists: %', v_username;
-            WHEN OTHERS THEN
-                RAISE NOTICE 'Warning creating role: %', SQLERRM;
-            END;
-        END IF;
-        
-        -- Grant each role to the user
-        FOREACH v_role IN ARRAY v_role_array LOOP
-            v_role := TRIM(v_role);
-            IF v_role <> '' THEN
-                BEGIN
-                    EXECUTE 'GRANT ' || quote_identifier(v_role) || ' TO ' || quote_identifier(v_username);
-                    RAISE NOTICE 'Granted role % to user %', v_role, v_username;
-                EXCEPTION WHEN OTHERS THEN
-                    RAISE NOTICE 'Warning granting role: %', SQLERRM;
-                END;
-            END IF;
-        END LOOP;
-    END LOOP;
-END
-\\\$\\\$;
-EOSQL
+echo "Setting database permissions for users: ${CLEANED_USERNAMES}"
+echo "Roles to assign: ${CLEANED_ROLES}"
+
+PSQL_CMD="psql -h ${PGHOST} -p ${PGPORT} -U ${DBADMINUSER} -d ${PGDATABASE}"
+
+# Split comma-separated usernames and roles
+IFS=',' read -ra USERS <<< "${CLEANED_USERNAMES}"
+IFS=',' read -ra ROLES <<< "${CLEANED_ROLES}"
+
+for USERNAME in "${USERS[@]}"; do
+  USERNAME=$(echo "${USERNAME}" | xargs)  # trim whitespace
+  echo "Processing user: ${USERNAME}"
+
+  # Create role if it doesn't exist
+  ${PSQL_CMD} -c "
+    DO \$\$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${USERNAME}') THEN
+        CREATE ROLE \"${USERNAME}\" WITH LOGIN;
+        RAISE NOTICE 'Role created: ${USERNAME}';
+      ELSE
+        RAISE NOTICE 'Role already exists: ${USERNAME}';
+      END IF;
+    END
+    \$\$;
+  "
+
+  # Grant each role to the user
+  for ROLE in "${ROLES[@]}"; do
+    ROLE=$(echo "${ROLE}" | xargs)  # trim whitespace
+    echo "Granting role ${ROLE} to ${USERNAME}"
+    ${PSQL_CMD} -c "GRANT \"${ROLE}\" TO \"${USERNAME}\";"
+  done
+done
 
 echo "PostgreSQL database permissions set successfully"

--- a/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sh
+++ b/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export PGPASSWORD="${DBADMINPWD}"
+export PGSSLMODE="require"
+
+# Set database permissions for users/groups/managed identities
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" -v DBUSERNAMES="${DBUSERNAMES}" -v DBROLES="${DBROLES}" -f "${SQLFILEPATH}"
+
+echo "PostgreSQL database permissions set successfully"

--- a/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sh
+++ b/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sh
@@ -4,7 +4,60 @@ set -e
 export PGPASSWORD="${DBADMINPWD}"
 export PGSSLMODE="require"
 
-# Set database permissions for users/groups/managed identities
-psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" -v DBUSERNAMES="${DBUSERNAMES}" -v DBROLES="${DBROLES}" -f "${SQLFILEPATH}"
+echo "Setting database permissions for users: ${DBUSERNAMES}"
+
+# Generate SQL dynamically with proper variable substitution
+psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBADMINUSER}" -d "${PGDATABASE}" << EOSQL
+DO \\\$\\\$
+DECLARE
+    v_usernames TEXT := '$(echo "${DBUSERNAMES}" | sed "s/'/''/g")';
+    v_roles TEXT := '$(echo "${DBROLES}" | sed "s/'/''/g")';
+    v_username TEXT;
+    v_role TEXT;
+    v_user_array TEXT[];
+    v_role_array TEXT[];
+BEGIN
+    -- Remove surrounding quotes and split by comma
+    v_usernames := TRIM(BOTH '''' FROM v_usernames);
+    v_roles := TRIM(BOTH '''' FROM v_roles);
+    
+    v_user_array := STRING_TO_ARRAY(v_usernames, ',');
+    v_role_array := STRING_TO_ARRAY(v_roles, ',');
+    
+    RAISE NOTICE 'Processing users: %', v_usernames;
+    RAISE NOTICE 'Assigning roles: %', v_roles;
+    
+    -- Process each username
+    FOREACH v_username IN ARRAY v_user_array LOOP
+        v_username := TRIM(v_username);
+        
+        -- Create role from external provider (AAD/Managed Identity) if needed
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = v_username) THEN
+            BEGIN
+                EXECUTE 'CREATE ROLE ' || quote_identifier(v_username) || ' WITH LOGIN';
+                RAISE NOTICE 'Role created for: %', v_username;
+            EXCEPTION WHEN duplicate_object THEN
+                RAISE NOTICE 'Role already exists: %', v_username;
+            WHEN OTHERS THEN
+                RAISE NOTICE 'Warning creating role: %', SQLERRM;
+            END;
+        END IF;
+        
+        -- Grant each role to the user
+        FOREACH v_role IN ARRAY v_role_array LOOP
+            v_role := TRIM(v_role);
+            IF v_role <> '' THEN
+                BEGIN
+                    EXECUTE 'GRANT ' || quote_identifier(v_role) || ' TO ' || quote_identifier(v_username);
+                    RAISE NOTICE 'Granted role % to user %', v_role, v_username;
+                EXCEPTION WHEN OTHERS THEN
+                    RAISE NOTICE 'Warning granting role: %', SQLERRM;
+                END;
+            END IF;
+        END LOOP;
+    END LOOP;
+END
+\\\$\\\$;
+EOSQL
 
 echo "PostgreSQL database permissions set successfully"

--- a/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sql
@@ -1,0 +1,62 @@
+-- Set PostgreSQL database permissions for users/groups/managed identities
+-- Creates external provider roles (AAD/Managed Identity) and assigns permissions
+
+DO $$
+DECLARE
+    v_dbusernames VARCHAR(2000) := :'DBUSERNAMES';
+    v_dbroles VARCHAR(2000) := :'DBROLES';
+    v_username VARCHAR(100);
+    v_role VARCHAR(100);
+    v_sql VARCHAR(500);
+    v_roles_list VARCHAR(2000);
+BEGIN
+    WHILE LENGTH(v_dbusernames) > 0 LOOP
+        -- Extract first username
+        IF POSITION(',' IN v_dbusernames) > 0 THEN
+            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
+            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
+        ELSE
+            v_username := v_dbusernames;
+            v_dbusernames := '';
+        END IF;
+
+        v_username := TRIM(v_username);
+
+        -- Create role from external provider (AAD / Managed Identity) if it doesn't exist
+        IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = v_username) THEN
+            v_sql := 'CREATE ROLE "' || v_username || '" WITH LOGIN';
+            BEGIN
+                EXECUTE v_sql;
+                RAISE NOTICE 'User % created from external provider', v_username;
+            EXCEPTION WHEN OTHERS THEN
+                RAISE NOTICE 'User % already exists or error creating: %', v_username, SQLERRM;
+            END;
+        ELSE
+            RAISE NOTICE 'User % already exists', v_username;
+        END IF;
+
+        -- Assign roles to the user
+        v_roles_list := :'DBROLES';
+        WHILE LENGTH(v_roles_list) > 0 LOOP
+            IF POSITION(',' IN v_roles_list) > 0 THEN
+                v_role := SUBSTRING(v_roles_list FROM 1 FOR POSITION(',' IN v_roles_list) - 1);
+                v_roles_list := SUBSTRING(v_roles_list FROM POSITION(',' IN v_roles_list) + 1);
+            ELSE
+                v_role := v_roles_list;
+                v_roles_list := '';
+            END IF;
+
+            v_role := TRIM(v_role);
+
+            -- Grant role to user
+            BEGIN
+                v_sql := 'GRANT "' || v_role || '" TO "' || v_username || '"';
+                EXECUTE v_sql;
+                RAISE NOTICE 'Granted role % to user %', v_role, v_username;
+            EXCEPTION WHEN OTHERS THEN
+                RAISE NOTICE 'Error granting role % to user %: %', v_role, v_username, SQLERRM;
+            END;
+        END LOOP;
+    END LOOP;
+END
+$$;

--- a/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sql
+++ b/modules/databases/postgresql_flexible_server/scripts/set_db_permissions.sql
@@ -1,62 +1,45 @@
--- Set PostgreSQL database permissions for users/groups/managed identities
--- Creates external provider roles (AAD/Managed Identity) and assigns permissions
+-- Set PostgreSQL database permissions for managed identities and AAD groups
+-- Handles multiple comma-separated usernames and roles
 
 DO $$
 DECLARE
-    v_dbusernames VARCHAR(2000) := :'DBUSERNAMES';
-    v_dbroles VARCHAR(2000) := :'DBROLES';
-    v_username VARCHAR(100);
-    v_role VARCHAR(100);
-    v_sql VARCHAR(500);
-    v_roles_list VARCHAR(2000);
+    v_usernames TEXT := :'DBUSERNAMES';
+    v_roles TEXT := :'DBROLES';
+    v_username TEXT;
+    v_role TEXT;
+    v_user_array TEXT[];
+    v_role_array TEXT[];
 BEGIN
-    WHILE LENGTH(v_dbusernames) > 0 LOOP
-        -- Extract first username
-        IF POSITION(',' IN v_dbusernames) > 0 THEN
-            v_username := SUBSTRING(v_dbusernames FROM 1 FOR POSITION(',' IN v_dbusernames) - 1);
-            v_dbusernames := SUBSTRING(v_dbusernames FROM POSITION(',' IN v_dbusernames) + 1);
-        ELSE
-            v_username := v_dbusernames;
-            v_dbusernames := '';
-        END IF;
-
+    -- Remove surrounding quotes and split by comma
+    v_usernames := TRIM(BOTH '''' FROM v_usernames);
+    v_roles := TRIM(BOTH '''' FROM v_roles);
+    
+    v_user_array := STRING_TO_ARRAY(v_usernames, ',');
+    v_role_array := STRING_TO_ARRAY(v_roles, ',');
+    
+    -- Process each username
+    FOREACH v_username IN ARRAY v_user_array LOOP
         v_username := TRIM(v_username);
-
-        -- Create role from external provider (AAD / Managed Identity) if it doesn't exist
-        IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = v_username) THEN
-            v_sql := 'CREATE ROLE "' || v_username || '" WITH LOGIN';
+        
+        -- Create role from external provider (AAD/Managed Identity) if needed
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = v_username) THEN
             BEGIN
-                EXECUTE v_sql;
-                RAISE NOTICE 'User % created from external provider', v_username;
-            EXCEPTION WHEN OTHERS THEN
-                RAISE NOTICE 'User % already exists or error creating: %', v_username, SQLERRM;
+                EXECUTE 'CREATE ROLE "' || v_username || '" WITH LOGIN';
+                RAISE NOTICE 'Role created for: %', v_username;
+            EXCEPTION WHEN duplicate_object THEN
+                RAISE NOTICE 'Role already exists: %', v_username;
+            WHEN OTHERS THEN
+                RAISE NOTICE 'Warning creating role %: %', v_username, SQLERRM;
             END;
-        ELSE
-            RAISE NOTICE 'User % already exists', v_username;
         END IF;
-
-        -- Assign roles to the user
-        v_roles_list := :'DBROLES';
-        WHILE LENGTH(v_roles_list) > 0 LOOP
-            IF POSITION(',' IN v_roles_list) > 0 THEN
-                v_role := SUBSTRING(v_roles_list FROM 1 FOR POSITION(',' IN v_roles_list) - 1);
-                v_roles_list := SUBSTRING(v_roles_list FROM POSITION(',' IN v_roles_list) + 1);
-            ELSE
-                v_role := v_roles_list;
-                v_roles_list := '';
-            END IF;
-
+        
+        -- Grant each role to the user
+        FOREACH v_role IN ARRAY v_role_array LOOP
             v_role := TRIM(v_role);
-
-            -- Grant role to user
-            BEGIN
-                v_sql := 'GRANT "' || v_role || '" TO "' || v_username || '"';
-                EXECUTE v_sql;
-                RAISE NOTICE 'Granted role % to user %', v_role, v_username;
-            EXCEPTION WHEN OTHERS THEN
-                RAISE NOTICE 'Error granting role % to user %: %', v_role, v_username, SQLERRM;
-            END;
-        END LOOP;
-    END LOOP;
-END
-$$;
+            IF v_role <> '' THEN
+                BEGIN
+                    EXECUTE 'GRANT "' || v_role || '" TO "' || v_username || '"';
+                    RAISE NOTICE 'Granted role % to user %', v_role, v_username;
+                EXCEPTION WHEN OTHERS THEN
+                    RAISE NOTICE 'Warning granting role %: %', v_role, SQLERRM;
+                END;\n            END IF;\n        END LOOP;\n    END LOOP;\nEND\n$$;


### PR DESCRIPTION
## PR Checklist

---

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This PR adds comprehensive user and permission management capabilities to the PostgreSQL Flexible Server module, enabling:

### Features Added

**1. Local Database User Management (`postgresql_users`)**
- Auto-generated secure passwords (128 chars, stored in Key Vault)
- Support for custom database roles (e.g., `pg_read_all_data`, `pg_write_all_data`)
- Create/delete lifecycle with automatic credential rotation

**2. Database Permissions (`db_permissions`)**
- Grant database roles to Managed Identities (MSI)
- Grant database roles to Azure AD groups
- Cross-landing-zone support for remote identities
- Automatic role creation and revocation on destroy

**3. Implementation Files**
- `locals_postgresql_users.tf` - Resolves MSI names and AAD group display names
- `db_users.tf` - Manages user creation and password storage
- `db_permissions.tf` - Manages identity-based role assignments
- Shell scripts for database operations (`create_pg_user.sh`, `set_db_permissions.sh`, `revoke_db_permissions.sh`)

**4. Example**
- `examples/postgresql_flexible_server/105-postgresql-flexible-with-users/` - Demonstrates:
  - Creating 2 local users with different roles
  - Granting MSI multiple database roles
  - Storing credentials in Key Vault

### Module Usage Example

```terraform
postgresql_users = {
  app_reader = {
    name     = "appreader"
    role     = "pg_read_all_data"
    database = "appdb"
  }
}

db_permissions = {
  app_msi_permissions = {
    database = "appdb"
    db_roles = ["pg_read_all_data", "pg_write_all_data"]
    managed_identities = {
      lz_key = ""
      keys   = ["app_msi"]
    }
  }
}

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

Azure PostgreSQL Flexible Server (v12+)
Azure Key Vault with permissions for the service principal
psql client installed in the executor environment (e.g., rover container)

