### PR TITLE
fix(pim): use resolved role_definition_id without scope prefix

### DIFF
--- a/modules/authorization/pim_eligible_role_assignments/locals.tf
+++ b/modules/authorization/pim_eligible_role_assignments/locals.tf
@@ -28,7 +28,7 @@ locals {
     try(local.eligible_role_definition_from_data, null)
   )
 
-  role_definition_id = try(startswith(local.role_definition_id_resolved, "/providers/"), false) ? "${local.scope}${local.role_definition_id_resolved}" : local.role_definition_id_resolved
+  role_definition_id = local.role_definition_id_resolved
 
   principal_id = coalesce(
     try(var.settings.principal_id, null),


### PR DESCRIPTION
## Summary
- remove scope-prefix concatenation from `role_definition_id`
- use `local.role_definition_id_resolved` directly in PIM eligible role assignments

## Why
This avoids constructing a potentially invalid `role_definition_id` when the resolved value is already in the expected format.

## Changes
- `modules/authorization/pim_eligible_role_assignments/locals.tf`

## Validation
- Branch pushed successfully
- Single focused change for PIM role definition resolution