### PR TITLE
feat: add PIM group assignments module and safe pim groups example

### DIFF
--- a/.github/workflows/standalone-scenarios.json
+++ b/.github/workflows/standalone-scenarios.json
@@ -112,6 +112,7 @@
     "cache/managed_redis/200-managed-redis-private-endpoint",
     "pim/100-pim",
     "pim/200-pim-standalone-selectors",
+    "pim/300-pim-groups",
     "role_mapping/100-simple-role-mapping",
     "role_mapping/101-function-app-managed-identity",
     "role_mapping/103-abac",

--- a/examples/pim/300-pim-groups/configuration.tfvars
+++ b/examples/pim/300-pim-groups/configuration.tfvars
@@ -1,0 +1,54 @@
+global_settings = {
+  default_region = "region1"
+  regions = {
+    region1 = "westeurope"
+  }
+  random_length = 5
+}
+
+azuread_groups = {
+  pim_target_group = {
+    name = "pim-target-group-1"
+  }
+
+  pim_principal_group = {
+    name = "pim-principal-group-1"
+  }
+}
+
+pim = {
+  pim_group_assignments = {
+    eligible_member_assignment = {
+      assignment_mode = "eligible"
+      assignment_type = "member"
+
+      group = {
+        key = "pim_target_group"
+      }
+
+      principal_group = {
+        key = "pim_principal_group"
+      }
+
+      justification = "Eligible assignment for privileged group membership"
+      duration      = "P30D"
+    }
+
+    active_owner_assignment = {
+      assignment_mode      = "active"
+      assignment_type      = "owner"
+      group = {
+        key = "pim_target_group"
+      }
+
+      principal_group = {
+        key = "pim_principal_group"
+      }
+
+      permanent_assignment = true
+      justification        = "Active owner assignment for emergency operations"
+      ticket_system        = "ServiceNow"
+      ticket_number        = "INC-30001"
+    }
+  }
+}

--- a/locals.combined_objects.tf
+++ b/locals.combined_objects.tf
@@ -167,6 +167,7 @@ locals {
   combined_objects_notification_hub_namespaces                   = merge(tomap({ (local.client_config.landingzone_key) = module.notification_hub_namespaces }), lookup(var.remote_objects, "notification_hub_namespaces", {}))
   combined_objects_pim_active_role_assignments                   = merge(tomap({ (local.client_config.landingzone_key) = module.pim_active_role_assignments }), lookup(var.remote_objects, "pim_active_role_assignments", {}))
   combined_objects_pim_eligible_role_assignments                 = merge(tomap({ (local.client_config.landingzone_key) = module.pim_eligible_role_assignments }), lookup(var.remote_objects, "pim_eligible_role_assignments", {}))
+  combined_objects_pim_group_assignments                         = merge(tomap({ (local.client_config.landingzone_key) = module.pim_group_assignments }), lookup(var.remote_objects, "pim_group_assignments", {}))
   combined_objects_pim_role_management_policies                  = merge(tomap({ (local.client_config.landingzone_key) = module.pim_role_management_policies }), lookup(var.remote_objects, "pim_role_management_policies", {}))
   combined_objects_postgresql_flexible_servers                   = merge(tomap({ (local.client_config.landingzone_key) = module.postgresql_flexible_servers }), lookup(var.remote_objects, "postgresql_flexible_servers", {}))
   combined_objects_private_dns = merge(

--- a/locals.tf
+++ b/locals.tf
@@ -561,6 +561,7 @@ locals {
   pim = {
     pim_active_role_assignments   = try(var.pim.pim_active_role_assignments, {})
     pim_eligible_role_assignments = try(var.pim.pim_eligible_role_assignments, {})
+    pim_group_assignments         = try(var.pim.pim_group_assignments, {})
     pim_role_management_policies  = try(var.pim.pim_role_management_policies, {})
   }
 }

--- a/modules/authorization/pim_group_assignments/data_sources.tf
+++ b/modules/authorization/pim_group_assignments/data_sources.tf
@@ -1,0 +1,46 @@
+locals {
+  group_data_lookup = (
+    try(local.group_selector.key, null) == null &&
+    try(local.group_selector.display_name, null) != null
+    ) ? {
+    this = local.group_selector
+  } : {}
+
+  principal_group_data_lookup = (
+    try(local.principal_group_selector.key, null) == null &&
+    try(local.principal_group_selector.display_name, null) != null
+    ) ? {
+    this = local.principal_group_selector
+  } : {}
+
+  principal_user_data_lookup = (
+    try(local.principal_user_selector.key, null) == null &&
+    try(local.principal_user_selector.user_principal_name, null) != null
+    ) ? {
+    this = local.principal_user_selector
+  } : {}
+}
+
+data "azuread_group" "group" {
+  for_each = local.group_data_lookup
+
+  display_name = each.value.display_name
+}
+
+data "azuread_group" "principal_group" {
+  for_each = local.principal_group_data_lookup
+
+  display_name = each.value.display_name
+}
+
+data "azuread_user" "principal_user" {
+  for_each = local.principal_user_data_lookup
+
+  user_principal_name = each.value.user_principal_name
+}
+
+locals {
+  group_id_from_data           = try(data.azuread_group.group["this"].object_id, null)
+  principal_group_id_from_data = try(data.azuread_group.principal_group["this"].object_id, null)
+  principal_user_id_from_data  = try(data.azuread_user.principal_user["this"].object_id, null)
+}

--- a/modules/authorization/pim_group_assignments/locals.tf
+++ b/modules/authorization/pim_group_assignments/locals.tf
@@ -1,0 +1,25 @@
+locals {
+  assignment_mode = lower(var.settings.assignment_mode)
+
+  group_selector = try(var.settings.group, null)
+
+  principal_group_selector = try(var.settings.principal_group, null)
+  principal_user_selector  = try(var.settings.principal_user, null)
+
+  group_id = coalesce(
+    try(var.settings.group_id, null),
+    try(var.remote_objects.azuread_groups[coalesce(try(local.group_selector.lz_key, null), var.client_config.landingzone_key)][local.group_selector.key].object_id, null),
+    try(var.remote_objects.azuread_groups[coalesce(try(local.group_selector.lz_key, null), var.client_config.landingzone_key)][local.group_selector.key].id, null),
+    try(local.group_id_from_data, null)
+  )
+
+  principal_id = coalesce(
+    try(var.settings.principal_id, null),
+    try(var.remote_objects.azuread_groups[coalesce(try(local.principal_group_selector.lz_key, null), var.client_config.landingzone_key)][local.principal_group_selector.key].object_id, null),
+    try(var.remote_objects.azuread_groups[coalesce(try(local.principal_group_selector.lz_key, null), var.client_config.landingzone_key)][local.principal_group_selector.key].id, null),
+    try(var.remote_objects.azuread_users[coalesce(try(local.principal_user_selector.lz_key, null), var.client_config.landingzone_key)][local.principal_user_selector.key].rbac_id, null),
+    try(var.remote_objects.azuread_users[coalesce(try(local.principal_user_selector.lz_key, null), var.client_config.landingzone_key)][local.principal_user_selector.key].object_id, null),
+    try(local.principal_group_id_from_data, null),
+    try(local.principal_user_id_from_data, null)
+  )
+}

--- a/modules/authorization/pim_group_assignments/outputs.tf
+++ b/modules/authorization/pim_group_assignments/outputs.tf
@@ -1,0 +1,25 @@
+output "id" {
+  value = coalesce(
+    try(azuread_privileged_access_group_assignment_schedule.active[0].id, null),
+    try(azuread_privileged_access_group_eligibility_schedule.eligible[0].id, null)
+  )
+}
+
+output "status" {
+  value = coalesce(
+    try(azuread_privileged_access_group_assignment_schedule.active[0].status, null),
+    try(azuread_privileged_access_group_eligibility_schedule.eligible[0].status, null)
+  )
+}
+
+output "assignment_mode" {
+  value = local.assignment_mode
+}
+
+output "group_id" {
+  value = local.group_id
+}
+
+output "principal_id" {
+  value = local.principal_id
+}

--- a/modules/authorization/pim_group_assignments/pim_group_assignment.tf
+++ b/modules/authorization/pim_group_assignments/pim_group_assignment.tf
@@ -1,0 +1,57 @@
+# Terraform resource docs:
+# - https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/privileged_access_group_assignment_schedule
+# - https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/privileged_access_group_eligibility_schedule
+
+resource "azuread_privileged_access_group_assignment_schedule" "active" {
+  count = local.assignment_mode == "active" ? 1 : 0
+
+  group_id        = local.group_id
+  principal_id    = local.principal_id
+  assignment_type = lower(var.settings.assignment_type)
+  justification   = try(var.settings.justification, null)
+  ticket_number   = try(var.settings.ticket_number, null)
+  ticket_system   = try(var.settings.ticket_system, null)
+  start_date      = try(var.settings.start_date, null)
+  expiration_date = try(var.settings.expiration_date, null)
+  duration        = try(var.settings.duration, null)
+
+  permanent_assignment = try(var.settings.permanent_assignment, null)
+
+  dynamic "timeouts" {
+    for_each = try(var.settings.timeouts, null) == null ? [] : [var.settings.timeouts]
+
+    content {
+      create = try(timeouts.value.create, null)
+      read   = try(timeouts.value.read, null)
+      update = try(timeouts.value.update, null)
+      delete = try(timeouts.value.delete, null)
+    }
+  }
+}
+
+resource "azuread_privileged_access_group_eligibility_schedule" "eligible" {
+  count = local.assignment_mode == "eligible" ? 1 : 0
+
+  group_id        = local.group_id
+  principal_id    = local.principal_id
+  assignment_type = lower(var.settings.assignment_type)
+  justification   = try(var.settings.justification, null)
+  ticket_number   = try(var.settings.ticket_number, null)
+  ticket_system   = try(var.settings.ticket_system, null)
+  start_date      = try(var.settings.start_date, null)
+  expiration_date = try(var.settings.expiration_date, null)
+  duration        = try(var.settings.duration, null)
+
+  permanent_assignment = try(var.settings.permanent_assignment, null)
+
+  dynamic "timeouts" {
+    for_each = try(var.settings.timeouts, null) == null ? [] : [var.settings.timeouts]
+
+    content {
+      create = try(timeouts.value.create, null)
+      read   = try(timeouts.value.read, null)
+      update = try(timeouts.value.update, null)
+      delete = try(timeouts.value.delete, null)
+    }
+  }
+}

--- a/modules/authorization/pim_group_assignments/providers.tf
+++ b/modules/authorization/pim_group_assignments/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 3.0.0"
+    }
+  }
+}

--- a/modules/authorization/pim_group_assignments/variables.tf
+++ b/modules/authorization/pim_group_assignments/variables.tf
@@ -1,0 +1,154 @@
+variable "settings" {
+  description = <<DESCRIPTION
+  Settings object for Entra ID PIM for groups assignment schedules. Configuration attributes:
+    - assignment_mode      - (Required) Target schedule type. Allowed values: "active", "eligible".
+    - assignment_type      - (Required) Group assignment type. Allowed values: "member", "owner".
+    - group_id             - (Optional) Object ID of the target privileged access group.
+    - group                - (Optional) Key-based or standalone selector for target group. Used when group_id is not provided.
+      - key                - (Optional) Key in remote_objects.azuread_groups.
+      - display_name       - (Optional) Display name for standalone lookup.
+      - lz_key             - (Optional) Landing zone key for cross-LZ references.
+    - principal_id         - (Optional) Object ID of the principal to assign.
+    - principal_group      - (Optional) Key-based or standalone selector for principal group. Used when principal_id is not provided.
+      - key                - (Optional) Key in remote_objects.azuread_groups.
+      - display_name       - (Optional) Display name for standalone lookup.
+      - lz_key             - (Optional) Landing zone key for cross-LZ references.
+    - principal_user       - (Optional) Key-based or standalone selector for principal user. Used when principal_id and principal_group are not provided.
+      - key                - (Optional) Key in remote_objects.azuread_users.
+      - user_principal_name - (Optional) UPN for standalone lookup.
+      - lz_key             - (Optional) Landing zone key for cross-LZ references.
+    - justification        - (Optional) Justification for the assignment request.
+    - ticket_number        - (Optional) Ticket number associated with the assignment request.
+    - ticket_system        - (Optional) Ticketing system associated with ticket_number.
+    - start_date           - (Optional) Assignment start date in RFC3339 format.
+    - expiration_date      - (Optional) Assignment expiration date in RFC3339 format.
+    - duration             - (Optional) Assignment duration in ISO8601 duration format (for example, "P30D" or "PT3H").
+    - permanent_assignment - (Optional) Whether the assignment is permanent.
+    - timeouts             - (Optional) Terraform operation timeouts.
+      - create             - (Optional) Timeout for create operations.
+      - read               - (Optional) Timeout for read operations.
+      - update             - (Optional) Timeout for update operations.
+      - delete             - (Optional) Timeout for delete operations.
+
+  One of expiration_date, duration, or permanent_assignment must be provided.
+  DESCRIPTION
+
+  type = object({
+    assignment_mode      = string
+    assignment_type      = string
+    group_id             = optional(string)
+    principal_id         = optional(string)
+    justification        = optional(string)
+    ticket_number        = optional(string)
+    ticket_system        = optional(string)
+    start_date           = optional(string)
+    expiration_date      = optional(string)
+    duration             = optional(string)
+    permanent_assignment = optional(bool)
+
+    group = optional(object({
+      key          = optional(string)
+      display_name = optional(string)
+      lz_key       = optional(string)
+    }))
+
+    principal_group = optional(object({
+      key          = optional(string)
+      display_name = optional(string)
+      lz_key       = optional(string)
+    }))
+
+    principal_user = optional(object({
+      key                 = optional(string)
+      user_principal_name = optional(string)
+      lz_key              = optional(string)
+    }))
+
+    timeouts = optional(object({
+      create = optional(string)
+      read   = optional(string)
+      update = optional(string)
+      delete = optional(string)
+    }))
+  })
+
+  validation {
+    condition = length(setsubtract(
+      keys(var.settings),
+      [
+        "assignment_mode",
+        "assignment_type",
+        "group_id",
+        "group",
+        "principal_id",
+        "principal_group",
+        "principal_user",
+        "justification",
+        "ticket_number",
+        "ticket_system",
+        "start_date",
+        "expiration_date",
+        "duration",
+        "permanent_assignment",
+        "timeouts"
+      ]
+    )) == 0
+
+    error_message = "Unsupported attributes in settings. Allowed: assignment_mode, assignment_type, group_id, group, principal_id, principal_group, principal_user, justification, ticket_number, ticket_system, start_date, expiration_date, duration, permanent_assignment, timeouts."
+  }
+
+  validation {
+    condition     = contains(["active", "eligible"], lower(var.settings.assignment_mode))
+    error_message = "settings.assignment_mode must be one of: active, eligible."
+  }
+
+  validation {
+    condition     = contains(["member", "owner"], lower(var.settings.assignment_type))
+    error_message = "settings.assignment_type must be one of: member, owner."
+  }
+
+  validation {
+    condition = (
+      var.settings.group_id != null ||
+      try(var.settings.group.key, null) != null ||
+      try(var.settings.group.display_name, null) != null
+    )
+    error_message = "One of group_id or group (key/display_name) must be provided."
+  }
+
+  validation {
+    condition = (
+      var.settings.principal_id != null ||
+      try(var.settings.principal_group.key, null) != null ||
+      try(var.settings.principal_group.display_name, null) != null ||
+      try(var.settings.principal_user.key, null) != null ||
+      try(var.settings.principal_user.user_principal_name, null) != null
+    )
+    error_message = "One of principal_id, principal_group, or principal_user must be provided."
+  }
+
+  validation {
+    condition = (
+      var.settings.expiration_date != null ||
+      var.settings.duration != null ||
+      try(var.settings.permanent_assignment, null) != null
+    )
+    error_message = "One of expiration_date, duration, or permanent_assignment must be provided."
+  }
+}
+
+variable "global_settings" {
+  description = "Global settings object (see module README.md)."
+  type        = any
+}
+
+variable "client_config" {
+  description = "Client configuration object (see module README.md)."
+  type        = any
+}
+
+variable "remote_objects" {
+  description = "Remote objects for cross-module references"
+  type        = any
+  default     = {}
+}

--- a/pim.tf
+++ b/pim.tf
@@ -32,6 +32,20 @@ module "pim_eligible_role_assignments" {
   }
 }
 
+module "pim_group_assignments" {
+  source   = "./modules/authorization/pim_group_assignments"
+  for_each = local.pim.pim_group_assignments
+
+  settings        = each.value
+  global_settings = local.global_settings
+  client_config   = local.client_config
+
+  remote_objects = {
+    azuread_groups = local.combined_objects_azuread_groups
+    azuread_users  = local.combined_objects_azuread_users
+  }
+}
+
 
 
 module "pim_role_management_policies" {
@@ -55,6 +69,10 @@ output "pim_active_role_assignments" {
 
 output "pim_eligible_role_assignments" {
   value = module.pim_eligible_role_assignments
+}
+
+output "pim_group_assignments" {
+  value = module.pim_group_assignments
 }
 
 


### PR DESCRIPTION
## Summary
- Added the new module under `modules/authorization/pim_group_assignments/` (`providers.tf`, `variables.tf`, `locals.tf`, `data_sources.tf`, `pim_group_assignment.tf`, `outputs.tf`).
- Wired the module into root integration points: `pim.tf`, `locals.tf`, and `locals.combined_objects.tf`.
- Added and registered the scenario `examples/pim/300-pim-groups/configuration.tfvars` in `.github/workflows/standalone-scenarios.json`.
- Replaced placeholder GUID usage in the PIM groups example with key-based references for safer, repeatable validation.

## Scope
This PR is limited to the PIM group assignments implementation path (module + root wiring + example + CI registration). Unrelated modules and scenarios are intentionally out of scope.

## Validation
- Verified root wiring exists and resolves through `pim.tf`, `locals.tf`, and `locals.combined_objects.tf`.
- Verified `examples/pim/300-pim-groups/configuration.tfvars` is present and included in `.github/workflows/standalone-scenarios.json`.
- Verified placeholder GUID tokens are not used in the new PIM groups example.
- Verified CI checks completed successfully for formatting/lint/security and the registered scenario path.