### PR TITLE
fix: update remote_objects keys for AKS cluster module

### DIFF
--- a/compute_aks_clusters.tf
+++ b/compute_aks_clusters.tf
@@ -29,10 +29,10 @@ module "aks_clusters" {
 
   remote_objects = {
     #subnet_id           = can(each.value.vnet.subnet_key) ? local.combined_objects_networking[try(each.value.vnet.lz_key, local.client_config.landingzone_key)][each.value.vnet.key].subnets[each.value.vnet.subnet_key].id : null
-    private_dns_zone_id    = can(each.value.settings.private_dns_zone.key) ? local.combined_objects_private_dns[try(each.value.settings.private_dns_zone.lz_key, local.client_config.landingzone_key)][each.value.settings.private_dns_zone.key].id : null
-    application_gateway_id = can(each.value.settings.ingress_application_gateway.key) ? local.combined_objects_application_gateway_platforms[try(each.value.settings.ingress_application_gateway.lz_key, local.client_config.landingzone_key)][each.value.settings.ingress_application_gateway.key] : null
-    pod_subnet_id          = can(each.value.settings.default_node_pool.pod_subnet_key) ? local.combined_objects_networking[try(each.value.settings.lz_key, var.client_config.landingzone_key)][each.value.settings.vnet_key].subnets[try(each.value.settings.default_node_pool.pod_subnet_key, each.value.settings.default_node_pool.pod_subnet.key)].id : null
-    vnet_subnet_id         = can(each.value.settings.default_node_pool.subnet_key) ? local.combined_objects_networking[try(each.value.settings.vnet.lz_key, each.value.settings.lz_key, var.client_config.landingzone_key)][try(each.value.settings.vnet.key, each.value.settings.vnet_key)].subnets[try(each.value.settings.default_node_pool.subnet_key, each.value.settings.default_node_pool.subnet.key)].id : null
+    private_dns_zone_id    = can(each.value.private_dns_zone.key) ? local.combined_objects_private_dns[try(each.value.private_dns_zone.lz_key, local.client_config.landingzone_key)][each.value.private_dns_zone.key].id : null
+    application_gateway_id = can(each.value.ingress_application_gateway.key) ? local.combined_objects_application_gateway_platforms[try(each.value.ingress_application_gateway.lz_key, local.client_config.landingzone_key)][each.value.ingress_application_gateway.key] : null
+    pod_subnet_id          = can(each.value.default_node_pool.pod_subnet_key) ? local.combined_objects_networking[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[try(each.value.default_node_pool.pod_subnet_key, each.value.default_node_pool.pod_subnet.key)].id : null
+    vnet_subnet_id         = can(each.value.default_node_pool.subnet_key) ? local.combined_objects_networking[try(each.value.vnet.lz_key, each.value.lz_key, var.client_config.landingzone_key)][try(each.value.vnet.key, each.value.vnet_key)].subnets[try(each.value.default_node_pool.subnet_key, each.value.default_node_pool.subnet.key)].id : null
     diagnostics            = local.combined_diagnostics
     managed_identities     = local.combined_objects_managed_identities
     vnets                  = local.combined_objects_networking


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Fixes the resolution of private_dns_zone in the AKS CAF module by correctly wiring it through remote_objects.

Previously, the module did not properly resolve the private DNS zone from local.combined_objects_private_dns, resulting in AKS defaulting to a system-managed private DNS zone even when a custom zone was provided.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

