### PR TITLE
Add cache managed redis role assignment

### DIFF
--- a/cache_managed_redis.tf
+++ b/cache_managed_redis.tf
@@ -9,10 +9,11 @@ module "managed_redis" {
     each.value.location,
     local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
   )
-  resource_group      = try(each.value.resource_group, {})
-  resource_group_name = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
-  base_tags           = try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
-  private_endpoints   = try(each.value.private_endpoints, {})
+  redis_role_assignment = try(each.value.redis_role_assignment, {})
+  resource_group        = try(each.value.resource_group, {})
+  resource_group_name   = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
+  base_tags             = local.global_settings.inherit_tags
+  private_endpoints     = try(each.value.private_endpoints, {})
   remote_objects = {
     diagnostics        = local.combined_diagnostics
     managed_identities = local.combined_objects_managed_identities

--- a/examples/cache/managed_redis/100-simple-managed-redis/configuration.tfvars
+++ b/examples/cache/managed_redis/100-simple-managed-redis/configuration.tfvars
@@ -42,6 +42,17 @@ cache = {
         # }
       }
 
+      # Optional: Role assignment configuration
+      # Supports both local (same landing zone) and remote (cross-landing-zone) managed identities
+      # redis_role_assignment = {
+      #   "Data Owner" = {
+      #     managed_identities = {
+      #       lz_key = ""
+      #       keys = ["key1"]
+      #     }
+      #   }
+      # }
+
       # Optional: Default database configuration
       default_database = {
         access_keys_authentication_enabled = true

--- a/modules/cache/managed_redis/access_policy_assignment.tf‎
+++ b/modules/cache/managed_redis/access_policy_assignment.tf‎
@@ -1,0 +1,8 @@
+resource "azurerm_managed_redis_access_policy_assignment" "role_assignments" {
+  for_each = length(local.redis_role_assignments_merged) > 0 ? {
+    for idx, assignment in local.redis_role_assignments_merged : idx => assignment
+  } : {}
+
+  managed_redis_id   = azurerm_managed_redis.managed_redis.id
+  object_id          = each.value.principal_id
+}

--- a/modules/cache/managed_redis/azurecaf_name.tf
+++ b/modules/cache/managed_redis/azurecaf_name.tf
@@ -1,12 +1,12 @@
 # CAF naming for Managed Redis
-# Note: azurecaf currently has no dedicated resource_type for managed redis; using generic passthrough via azurecaf_name with resource_type "generic".
+# Note: azurecaf currently has no dedicated resource_type for managed redis; using azurerm_redis_cache resourcetype via azurecaf_name.
+
 resource "azurecaf_name" "managed_redis" {
   name          = var.settings.name
-  resource_type = try(var.settings.azurecaf_resource_type, "generic")
-  prefixes      = try(var.global_settings.prefixes, null)
-  suffixes      = try(var.global_settings.suffixes, null)
-  random_length = try(var.global_settings.random_length, 0)
+  resource_type = "azurerm_redis_cache"
+  prefixes      = var.global_settings.prefixes
+  random_length = var.global_settings.random_length
   clean_input   = true
-  passthrough   = try(var.global_settings.passthrough, false)
-  use_slug      = try(var.global_settings.use_slug, true)
+  passthrough   = var.global_settings.passthrough
+  use_slug      = var.global_settings.use_slug
 }

--- a/modules/cache/managed_redis/locals.tf
+++ b/modules/cache/managed_redis/locals.tf
@@ -7,4 +7,18 @@ locals {
 
   location            = coalesce(var.location, try(var.resource_group.location, null))
   resource_group_name = coalesce(var.resource_group_name, try(var.resource_group.name, null))
+
+  redis_role_assignments_flat = {
+    for role_name, role_data in try(var.redis_role_assignment, {}) :
+    role_name => [
+      for key in role_data.managed_identities.keys : {
+
+        lz_key = contains(keys(role_data.managed_identities), "lz_key") ? role_data.managed_identities.lz_key : var.client_config.landingzone_key
+
+        principal_id = var.remote_objects.managed_identities[try(role_data.managed_identities.lz_key, var.client_config.landingzone_key)][key].principal_id
+      }
+    ]
+  }
+
+  redis_role_assignments_merged = flatten([for v in values(local.redis_role_assignments_flat) : v])
 }

--- a/modules/cache/managed_redis/variables.tf
+++ b/modules/cache/managed_redis/variables.tf
@@ -101,7 +101,7 @@ variable "base_tags" {
 
 variable "remote_objects" {
   description = "Remote objects map (diagnostics, keyvaults, etc.)."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -137,6 +137,12 @@ variable "vnets" {
 
 variable "virtual_subnets" {
   description = "Virtual subnets map used to resolve subnet references for private endpoints. Backward compatibility fallback when remote_objects.virtual_subnets is not provided."
+  type        = any
+  default     = {}
+}
+
+variable "redis_role_assignment" {
+  description = "Role assignments for the Managed Redis instance. This should be a map of role names to role assignment configurations, which include the managed identities to assign the role to. Example: { \"Reader\" = { managed_identities = { \"mi1\" = {}, \"mi2\" = {} } } }"
   type        = any
   default     = {}
 }


### PR DESCRIPTION
## PR Checklist

---

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add redis role assignment in managed_redis module

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing
``` 
       redis_role_assignment = {
         "Data Owner" = {
           managed_identities = {
             lz_key = ""
             keys = ["key1"]
           }
         }
       }
```
