### PR TITLE
fix(security_policy): add frontdoor_custom_domains to dependencies

### DIFF
--- a/modules/cdn/cdn_frontdoor_profile/security_policy.tf
+++ b/modules/cdn/cdn_frontdoor_profile/security_policy.tf
@@ -13,7 +13,8 @@ module "security_policies" {
     cdn_frontdoor_profile           = azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile
     cdn_frontdoor_firewall_policies = module.firewall_policies
     cdn_frontdoor_endpoints         = module.endpoints
+    cdn_frontdoor_custom_domains    = { (var.client_config.landingzone_key) = module.frontdoor_custom_domains }
   })
 
-  depends_on = [module.firewall_policies, module.endpoints]
+  depends_on = [module.firewall_policies, module.endpoints, module.frontdoor_custom_domains]
 }


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

To fix this error when I want to associate a custom domain to the waf policy.

```
│ Error: Error in function call
│ 
│   on /home/vscode/.terraform.cache/vvd/modules/solution/modules/cdn/cdn_frontdoor_profile/security_policy/security_policy.tf line 26, in resource "azurerm_cdn_frontdoor_security_policy" "security_policy":
│   26:               cdn_frontdoor_domain_id = coalesce(
│   27:                 try(domain.value.cdn_frontdoor_domain_id, null),
│   28:                 try(var.remote_objects.cdn_frontdoor_endpoints[domain.value.cdn_frontdoor_endpoint.key].id, null),
│   29:                 try(var.remote_objects.cdn_frontdoor_custom_domains[try(domain.value.cdn_frontdoor_custom_domain.lz_key, var.client_config.landingzone_key)][domain.value.cdn_frontdoor_custom_domain.key].id, null),
│   30:                 try(var.remote_objects.cdn_frontdoor_endpoints[try(domain.value.cdn_frontdoor_endpoint.lz_key, var.client_config.landingzone_key)][domain.value.cdn_frontdoor_endpoint.key].id, null)
│   31:               )
│     ├────────────────
│     │ domain.value is object with 1 attribute "cdn_frontdoor_custom_domain"
│     │ domain.value.cdn_frontdoor_custom_domain is object with 1 attribute "key"
│     │ domain.value.cdn_frontdoor_custom_domain.key is "domain1"
│     │ var.client_config.landingzone_key is "hub_networking"
│     │ var.remote_objects is object with 9 attributes
│     │ var.remote_objects.cdn_frontdoor_endpoints is object with 3 attributes
│ 
│ Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

```
    security_policies = {
      identity_security_policy = {
        name = "identity-test"

        security_policies = {
          firewall = {
            firewall_policy_key = "static_website_waf"

            association = {
              main_association = {
                domain = {
                  main_endpoint = {
                    cdn_frontdoor_endpoint = {
                      key = "endpoint1" 
                    }
                  }
                  main_custom_domain = {
                    cdn_frontdoor_custom_domain = {
                      key = "domain1"
                    }
                  }
                }
                patterns_to_match = ["/*"]
              }
            }
          }
        }
      }
    }
 ```
