### PR TITLE
Enhance log scrubbing settings for waf policy

### DIFF
--- a/examples/networking/app_gateway/102-waf-policy/waf.tfvars
+++ b/examples/networking/app_gateway/102-waf-policy/waf.tfvars
@@ -63,6 +63,39 @@ application_gateway_waf_policies = {
       request_body_check          = true
       file_upload_limit_in_mb     = 100
       max_request_body_size_in_kb = 128
+
+      log_scrubbing = {
+        enabled = true
+
+        rules = {
+          r1 = {
+            enabled                 = true
+            match_variable          = "RequestHeaderNames"
+            selector_match_operator = "Equals"
+            selector                = "Authorization"
+          }
+
+          r2 = {
+            enabled                 = true
+            match_variable          = "RequestCookieNames"
+            selector_match_operator = "Equals"
+            selector                = "sessionid"
+          }
+
+          r3 = {
+            enabled                 = true
+            match_variable          = "RequestArgNames"
+            selector_match_operator = "Equals"
+            selector                = "password"
+          }
+
+          r4 = {
+            enabled                 = true
+            match_variable          = "RequestIPAddress"
+            selector_match_operator = "EqualsAny"
+          }
+        }
+      }
     }
 
     managed_rules = {

--- a/modules/networking/application_gateway_waf_policies/waf_policy.tf
+++ b/modules/networking/application_gateway_waf_policies/waf_policy.tf
@@ -42,11 +42,32 @@ resource "azurerm_web_application_firewall_policy" "wafpolicy" {
   dynamic "policy_settings" {
     for_each = try(var.settings.policy_settings, {}) != {} ? [1] : []
     content {
-      enabled                     = try(var.settings.policy_settings.enabled, null)
-      mode                        = try(var.settings.policy_settings.mode, null)
-      file_upload_limit_in_mb     = try(var.settings.policy_settings.file_upload_limit_in_mb, null)
-      request_body_check          = try(var.settings.policy_settings.request_body_check, null)
-      max_request_body_size_in_kb = try(var.settings.policy_settings.max_request_body_size_in_kb, null)
+      enabled                                   = try(var.settings.policy_settings.enabled, null)
+      mode                                      = try(var.settings.policy_settings.mode, null)
+      file_upload_limit_in_mb                   = try(var.settings.policy_settings.file_upload_limit_in_mb, null)
+      request_body_check                        = try(var.settings.policy_settings.request_body_check, null)
+      max_request_body_size_in_kb               = try(var.settings.policy_settings.max_request_body_size_in_kb, null)
+      request_body_enforcement                  = try(var.settings.policy_settings.request_body_enforcement, true)
+      request_body_inspect_limit_in_kb          = try(var.settings.policy_settings.request_body_inspect_limit_in_kb, null)
+      js_challenge_cookie_expiration_in_minutes = try(var.settings.policy_settings.js_challenge_cookie_expiration_in_minutes, 30)
+      file_upload_enforcement                   = try(var.settings.policy_settings.file_upload_enforcement, true)
+
+      dynamic "log_scrubbing" {
+        for_each = try(var.settings.policy_settings.log_scrubbing, {}) != {} ? [1] : []
+        content {
+          enabled = try(var.settings.policy_settings.log_scrubbing.enabled, true)
+
+          dynamic "rule" {
+            for_each = try(var.settings.policy_settings.log_scrubbing.rules, {})
+            content {
+              enabled                 = try(rule.value.enabled, true)
+              match_variable          = rule.value.match_variable
+              selector_match_operator = try(rule.value.selector_match_operator, "Equals")
+              selector                = try(rule.value.selector, null)
+            }
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add `log_scrubbing`, `request_body_enforcement`, `request_body_inspect_limit_in_kb`, `js_challenge_cookie_expiration_in_minutes` and `file_upload_enforcement` support to the WAF policy module policy_settings block to allow scrubbing sensitive data from WAF log

## Does this introduce a breaking change

- [ ] YES
- [x] NO


## Testing

/examples/networking/app_gateway/102-waf-policy
