### PR TITLE
feat(aks): add vertical pod autoscaler support to workload autoscaler…

### DIFF
--- a/modules/compute/aks/kubernetes_cluster.tf
+++ b/modules/compute/aks/kubernetes_cluster.tf
@@ -437,7 +437,8 @@ node_os_upgrade_channel must be set to NodeImage if automatic_upgrade_channel ha
   dynamic "workload_autoscaler_profile" {
     for_each = try(var.settings.workload_autoscaler_profile[*], {})
     content {
-      keda_enabled = try(workload_autoscaler_profile.value.keda_enabled, null)
+      keda_enabled                    = try(workload_autoscaler_profile.value.keda_enabled, null)
+      vertical_pod_autoscaler_enabled = try(workload_autoscaler_profile.value.vertical_pod_autoscaler_enabled, null)
     }
   }
 


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have added example(s) inside the [./examples/] folder
- [x] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add `vertical_pod_autoscaler_enabled` support to the kubernetes cluster module `workload_autoscaler_profile` block to enable vpa

## Does this introduce a breaking change

- [ ] YES
- [x] NO


